### PR TITLE
twitchからランキング上位２００件取得するAPIの実装

### DIFF
--- a/src/app/api/getTopGames/route.ts
+++ b/src/app/api/getTopGames/route.ts
@@ -1,0 +1,44 @@
+import { TwitchTopGameType } from '@/types/TwitchTopGame';
+import { NextResponse } from 'next/server';
+
+export async function GET(req: Request) {
+  const TWITCH_API_URL = 'https://api.twitch.tv/helix/games/top?first=100'
+  
+  const headers = new Headers();
+  if (process.env.TWITCH_CLIENT_ID && process.env.TWITCH_ACCESS_TOKEN) {
+    headers.append('Client-ID', process.env.TWITCH_CLIENT_ID);
+    headers.append('Authorization', `Bearer ${process.env.TWITCH_ACCESS_TOKEN}`);
+  } else {
+    return NextResponse.error()
+  }
+
+  // 1~100件目のデータを取得
+  const firstRes = await fetch(TWITCH_API_URL,{headers: headers,})
+  const firstData = await firstRes.json()
+  const pageCursor = firstData.pagination.cursor
+  const firstGames = firstData.data.map((game: TwitchTopGameType) => {
+    return ({
+      twitchGameId: game.id,
+      title: game.name,
+    })
+  })
+
+  // 100~200件目のデータを取得
+  const secondRes = await fetch(
+    `${TWITCH_API_URL}&after=${pageCursor}`,
+    {
+      headers: headers,
+    }
+  )
+  const secondData = await secondRes.json()
+  const secondGames = secondData.data.map((game: TwitchTopGameType) => {
+    return ({
+      twitchGameId: game.id,
+      title: game.name,
+    })
+  })
+
+  const games = firstGames.concat(secondGames)
+
+  return NextResponse.json(games)
+}

--- a/src/constants/bunWords.ts
+++ b/src/constants/bunWords.ts
@@ -1,0 +1,22 @@
+export const BAN_WORDS = [
+    'Just Chatting',
+    'IRL',
+    'Sports',
+    'ASMR',
+    'Music',
+    'Slots',
+    'Art',
+    'Games + Demos',
+    'Retro',
+    'Animals, Aquariums, and Zoos',
+    'Always On',
+    'Kings League',
+    'Special Events',
+    'Chess',
+    'Talk Shows & Podcasts',
+    'Politics',
+    'Software and Game Development',
+    'Food & Drink',
+    'Makers & Crafting',
+    'Poker'
+]

--- a/src/hooks/getNextAPIData.ts
+++ b/src/hooks/getNextAPIData.ts
@@ -1,0 +1,10 @@
+export async function getNextAPIData(url: string) {
+
+  const res = await fetch(`http://localhost:3000${url}`)
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch data')
+  }
+
+  return res.json()
+}

--- a/src/hooks/getTopGames.ts
+++ b/src/hooks/getTopGames.ts
@@ -1,4 +1,4 @@
-export async function getNextAPIData(url: string) {
+export async function getTopGames() {
 
     const res = await fetch(`http://localhost:3000/api/getTopGames`)
   

--- a/src/hooks/getTopGames.ts
+++ b/src/hooks/getTopGames.ts
@@ -1,0 +1,11 @@
+export async function getNextAPIData(url: string) {
+
+    const res = await fetch(`http://localhost:3000/api/getTopGames`)
+  
+    if (!res.ok) {
+      throw new Error('Failed to fetch data')
+    }
+  
+    return res.json()
+  }
+  

--- a/src/types/TwitchTopGame.ts
+++ b/src/types/TwitchTopGame.ts
@@ -1,0 +1,6 @@
+export type TwitchTopGameType = {
+  id: string;
+  name: string;
+  box_art_url: string;
+  igdb_id?: number;
+};


### PR DESCRIPTION
-  api/getTopGames の位置に配置
- TwichのゲームIDとゲーム名のオブジェクト型配列を返すようにしてる
- 一応 constants 配下に禁止ワードの配列を作ったので、もし使うことになればそこからで
- 初期表示のときのみデータ取得とのことで、サーバーサイドでデータ取得できるように hooks/getTopGamesに実装
  -  取得方法はサーバーコンポーネント（page.tsxとか）で asyncをつける。その中で await getTopGames() で呼び出すことで取得できる
  - エラー処理書かないなら関数のところをfetch(URL)でもいける
![image](https://github.com/vdslab/steam-suggester/assets/114901771/eb9727f5-bb49-47d1-a4d3-d730f7785075)

- ネットワークのファイルができたらフック削除してもいいし、getNextAPIDataでエラー処理を使いまわしても可