### PR TITLE
流行度グラフの表示の修正

### DIFF
--- a/src/app/api/popularity/countSteamReviews/[gameId]/route.ts
+++ b/src/app/api/popularity/countSteamReviews/[gameId]/route.ts
@@ -1,0 +1,23 @@
+import { Rollups } from "@/types/Popularity/CountSteamReviews";
+import { NextResponse } from "next/server";
+
+type Params = {
+  params: {
+    gameId: string;
+  };
+};
+
+export async function GET(req: Request, { params }: Params) {
+
+  const gameID = params.gameId;
+  const response = await fetch(`https://store.steampowered.com/appreviewhistogram/${gameID}?json=1`)
+  const data = await response.json()
+
+  const reviewsCount = data.results.rollups.map((rollup:Rollups) => ({
+    date: rollup.date,
+    count: (rollup.recommendations_down + rollup.recommendations_up),
+  }))
+
+
+  return NextResponse.json(reviewsCount);
+}

--- a/src/components/popularity/Popularity.tsx
+++ b/src/components/popularity/Popularity.tsx
@@ -10,7 +10,7 @@ const Popularity = async() => {
     <div>
       <Headline txt="流行度" />
       {data ? (
-        <StackedAreaChart data={data} width={350} height={200}  />
+        <StackedAreaChart data={data} width={400} height={270}  />
       ) : null}
       
     </div>

--- a/src/components/popularity/Popularity.tsx
+++ b/src/components/popularity/Popularity.tsx
@@ -1,12 +1,10 @@
-'use client';
 import Headline from "../common/Headline"
 import StackedAreaChart from "./StackedAreaChart"
-import useCountSteamReview from "@/hooks/popularity/useCountSteamReviews";
 
-const Popularity = () => {
+const Popularity = async() => {
 
-  const { data, error, isLoading} = useCountSteamReview(271590)
-
+  const response = await fetch(`http://localhost:3000/api/popularity/countSteamReviews/1172470`);
+  const data = await response.json();
 
   return (
     <div>

--- a/src/components/popularity/StackedAreaChart.tsx
+++ b/src/components/popularity/StackedAreaChart.tsx
@@ -7,7 +7,7 @@ import { StackedAreasProps } from '@/types/Popularity/StackedAreaProps';
 import { BG_COLOR_STACKED_AREA } from '@/constants/styles/stackedArea';
 import { AxisBottom, AxisLeft } from '@visx/axis';
 
-const getX = (d: CountSteamReviews) => d.date;
+const getX = (d: CountSteamReviews) => d.date * 1000;
 const getY0 = (d: SeriesPoint<CountSteamReviews>) => d[0];
 const getY1 = (d: SeriesPoint<CountSteamReviews>) => d[1];
 
@@ -15,7 +15,7 @@ const StackedAreaChart =({
   data,
   width,
   height,
-  margin = { top: 0, right: 0, bottom: 0, left: 0 },
+  margin = { top: 10, right: 0, bottom: 0, left: 0 },
   events = false,
 }: StackedAreasProps) => {
   const yMax = height - margin.top - margin.bottom;
@@ -33,29 +33,29 @@ const StackedAreaChart =({
 
   const xScale = scaleTime<number>({
     range: [0, xMax],
-    domain: [Math.min(...data.map((d) => d.date)), Math.max(...data.map((d) => d.date))]
+    domain: [Math.min(...data.map((d) => d.date * 1000)), Math.max(...data.map((d) => d.date * 1000))]
   });
   const yScale = scaleLinear<number>({
     range: [yMax, 0],
     domain: [0, Math.max(...data.map((d) => d.count))],
-  });
+  }).nice();
 
   console.log(xScale.domain());
 
   return width < 10 ? null : (
     <svg width={width+ 100} height={height +50}>
       {/* <GradientOrangeRed id="stacked-area-orangered" /> */}
-      <rect x={70} y={0} width={width} height={height} fill={BG_COLOR_STACKED_AREA} rx={14} />
-      <AxisBottom scale={xScale} label='時間(h)' top={yMax} left={70} />
-      <AxisLeft scale={yScale} label='レビュー数' left={70} top={0}/>
+      <rect x={70} y={margin.top} width={width} height={height -margin.top} fill={BG_COLOR_STACKED_AREA} />
+      <AxisBottom scale={xScale} label='時間(年)' top={yMax+margin.top} left={70} hideZero numTicks={5} />
+      <AxisLeft scale={yScale} label='レビュー数' left={70} top={margin.top} labelOffset={50}/>
       <AreaStack
         top={margin.top}
         left={margin.left}
         keys={keys}
         data={data}
         x={(d) => xScale(getX(d.data)) + 70 ?? 0}
-        y0={(d) => yScale(getY0(d)) ?? 0}
-        y1={(d) => yScale(getY1(d)) ?? 0}
+        y0={(d) => yScale(getY0(d)) + margin.top ?? 0}
+        y1={(d) => yScale(getY1(d)) + margin.top ?? 0}
       >
         {({ stacks, path }) =>
           stacks.map((stack) => {

--- a/src/components/popularity/StackedAreaChart.tsx
+++ b/src/components/popularity/StackedAreaChart.tsx
@@ -5,13 +5,11 @@ import { scaleTime, scaleLinear, scaleOrdinal } from '@visx/scale';
 import { CountSteamReviews } from '@/types/Popularity/CountSteamReviews';
 import { StackedAreasProps } from '@/types/Popularity/StackedAreaProps';
 import { BG_COLOR_STACKED_AREA } from '@/constants/styles/stackedArea';
-import { AxisBottom, AxisLeft, AxisRight } from '@visx/axis';
+import { AxisBottom, AxisLeft } from '@visx/axis';
 
 const getX = (d: CountSteamReviews) => d.date;
-const getY0 = (d: SeriesPoint<CountSteamReviews>) => d[0] / 100;
-const getY1 = (d: SeriesPoint<CountSteamReviews>) => d[1] / 100;
-
-
+const getY0 = (d: SeriesPoint<CountSteamReviews>) => d[0];
+const getY1 = (d: SeriesPoint<CountSteamReviews>) => d[1];
 
 const StackedAreaChart =({
   data,
@@ -23,7 +21,10 @@ const StackedAreaChart =({
   const yMax = height - margin.top - margin.bottom;
   const xMax = width - margin.left - margin.right;
 
+
   const keys = Object.keys(data[0]).filter((k) => k !== 'date');
+
+  // console.log(data);
 
   const colorScale = scaleOrdinal<string, string>({
     domain: keys,
@@ -32,24 +33,27 @@ const StackedAreaChart =({
 
   const xScale = scaleTime<number>({
     range: [0, xMax],
-    domain: data ? [Math.min(...data.map((d) => d.date)), Math.max(...data.map((d) => d.date))] : [0, 0]
+    domain: [Math.min(...data.map((d) => d.date)), Math.max(...data.map((d) => d.date))]
   });
   const yScale = scaleLinear<number>({
     range: [yMax, 0],
+    domain: [0, Math.max(...data.map((d) => d.count))],
   });
+
+  console.log(xScale.domain());
 
   return width < 10 ? null : (
     <svg width={width+ 100} height={height +50}>
       {/* <GradientOrangeRed id="stacked-area-orangered" /> */}
-      <rect x={0} y={0} width={width} height={height} fill={BG_COLOR_STACKED_AREA} rx={14} />
-      <AxisBottom scale={xScale} label='時間(h)' top={yMax}/>
-      <AxisRight scale={yScale} label='人数' left={xMax}/>
+      <rect x={70} y={0} width={width} height={height} fill={BG_COLOR_STACKED_AREA} rx={14} />
+      <AxisBottom scale={xScale} label='時間(h)' top={yMax} left={70} />
+      <AxisLeft scale={yScale} label='レビュー数' left={70} top={0}/>
       <AreaStack
         top={margin.top}
         left={margin.left}
         keys={keys}
         data={data}
-        x={(d) => xScale(getX(d.data)) ?? 0}
+        x={(d) => xScale(getX(d.data)) + 70 ?? 0}
         y0={(d) => yScale(getY0(d)) ?? 0}
         y1={(d) => yScale(getY1(d)) ?? 0}
       >


### PR DESCRIPTION
-  流行度グラフの値をサーバー側で取得するように変更
- 上記に伴い値を動的に受け取れるように変更
- 現在ほかのコンポーネントもApexのデータを用いて画面を実装しているので、Apexのレビュー数データに変更
  - 確認した限り公式サイトの表示とは一致しています
- 横軸と縦軸のラベルの表示がかぶっていて消えたりしていたバグ修正
- 横軸はいったん年数ごとのラベル表示
- もうちょっとコードをきれいにできると思うのであらかた実装した後修正します、、、