### PR TITLE
APIのTwitchとSteamのAPIの連携と修正

### DIFF
--- a/src/app/api/getMatchDetails/[steamGameId]/[twitchGameId]/route.ts
+++ b/src/app/api/getMatchDetails/[steamGameId]/[twitchGameId]/route.ts
@@ -1,0 +1,44 @@
+import { gameDetailType } from "@/types/api/gameDetailsType";
+import { steamGameGenreType, steamGameCategoryType } from "@/types/api/steamDataType";
+import { NextResponse } from "next/server";
+
+type Params = {
+  params: {
+    steamGameId: string;
+    twitchGameId: string;
+  }
+};
+
+export async function GET(req: Request, params: Params) {
+
+  const { steamGameId, twitchGameId } = params.params;
+
+  const response = await fetch(`https://store.steampowered.com/api/appdetails?appids=${steamGameId}&cc=jp`)
+  const responseJson = await response.json()
+  const gameDetailData = responseJson[steamGameId].data
+
+  const result: gameDetailType = {
+    twitchGameId: twitchGameId,
+    steamGameId: steamGameId,
+    title: gameDetailData.name,
+    imgURL: gameDetailData.header_image,
+    gameData: {
+      genres: gameDetailData.genres.map((genre: steamGameGenreType) => genre.description),
+      price: gameDetailData.price_overview.final,
+      isSinglePlayer: gameDetailData.categories.some((category: steamGameCategoryType) => category.id === 2),
+      isMultiPlayer: gameDetailData.categories.some((category: steamGameCategoryType) => category.id === 1),
+      platforms: {
+        windows: gameDetailData.platforms.windows,
+        mac: gameDetailData.platforms.mac,
+        linux: gameDetailData.platforms.linux
+      }
+    }
+  }
+
+  let test = result
+
+
+
+
+  return NextResponse.json(test);
+}

--- a/src/app/api/network/getGameDetails/route.ts
+++ b/src/app/api/network/getGameDetails/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from 'next/server';
 
 export async function GET(req: Request) {
 
-  const response = await fetch(`http://localhost:3000/api/getTopGames`)
+  const response = await fetch(`${process.env.CURRENT_URL}/api/getTopGames`)
   const twitchGameNames = await response.json()
 
   const resultArray: gameDetailType[] = [];

--- a/src/app/api/network/getGameDetails/route.ts
+++ b/src/app/api/network/getGameDetails/route.ts
@@ -1,0 +1,60 @@
+import { gameDetailType, steamGamePlatformType, steamGameGenreType, steamGameCategoryType } from '@/types/api/getGameDetailsType';
+import { NextResponse } from 'next/server';
+
+export async function GET(req: Request) {
+
+  const response = await fetch(`http://localhost:3000/api/getTopGames`)
+  const twitchGameNames = await response.json()
+
+  const resultArray: gameDetailType[] = [];
+
+  for (const game of twitchGameNames) {
+
+    // steamAPIでゲームタイトルからタイトル、steamID、画像URL、価格、プラットフォームを取得
+    const res = await fetch(`https://store.steampowered.com/api/storesearch/?term=${game.title}&cc=JP`)
+    const resJson = await res.json()
+    const firstMatchGame = resJson.items[0]
+    // steamAPIでゲームタイトルから取得できなかった場合は次のゲームに移る
+    if (!firstMatchGame) {
+      continue
+    }
+    // 上記の情報を宣言
+    const steamGameId:string  = firstMatchGame.id
+    const title: string       = firstMatchGame.name
+    const imgURL: string      = firstMatchGame.header_image
+    const price:number        = firstMatchGame.price ? firstMatchGame.price.final : 0
+    const platforms:steamGamePlatformType = {
+      windows: firstMatchGame.platforms.windows,
+      mac: firstMatchGame.platforms.mac,
+      linux: firstMatchGame.platforms.linux
+    }
+    
+
+    // steamAPIでゲームIDからジャンル、プレイヤー数がどうか、プレイ時間、カテゴリーを取得
+    const response = await fetch(`https://store.steampowered.com/api/appdetails?appids=${steamGameId}&cc=jp`)
+    const responseJson = await response.json()
+    const gameDetailData = responseJson[steamGameId].data
+    // 上記の情報を宣言。２はシングルプレイヤー、１はマルチプレイヤー
+    const genres: string[]        = gameDetailData.genres.map( (genre: steamGameGenreType) => genre.description)
+    const isSinglePlayer: boolean = gameDetailData.categories.some((category: steamGameCategoryType) => category.id === 2)
+    const isMultiPlayer: boolean  = gameDetailData.categories.some((category: steamGameCategoryType) => category.id === 1)
+
+    // 結果を配列に格納
+    resultArray.push({
+      twitchGameId: game.twitchGameId,
+      steamGameId: steamGameId,
+      title: title,
+      imgURL: imgURL,
+      gameData: {
+        genres : genres,
+        price: price,
+        isSinglePlayer: isSinglePlayer,
+        isMultiPlayer: isMultiPlayer,
+        platforms: platforms,
+      }
+    })
+    
+  }
+
+  return NextResponse.json(resultArray);
+}

--- a/src/app/api/network/getGameDetails/route.ts
+++ b/src/app/api/network/getGameDetails/route.ts
@@ -1,4 +1,5 @@
-import { gameDetailType, steamGamePlatformType, steamGameGenreType, steamGameCategoryType } from '@/types/api/getGameDetailsType';
+import { gameDetailType } from '@/types/api/gameDetailsType';
+import { steamGamePlatformType, steamGameGenreType, steamGameCategoryType } from '@/types/api/steamDataType';
 import { NextResponse } from 'next/server';
 
 export async function GET(req: Request) {

--- a/src/components/distributorVideos/DistributorVideos.tsx
+++ b/src/components/distributorVideos/DistributorVideos.tsx
@@ -4,7 +4,7 @@ import DisplayClip from "./DisplayClip"
 const DistributorVideos = async() => {
 
 
-  const res = await fetch('http://localhost:3000/api/distributorVideos/getTwitchClips')
+  const res = await fetch(`${process.env.CURRENT_URL}/api/distributorVideos/getTwitchClips`)
   const data = await res.json()
 
 

--- a/src/components/popularity/Popularity.tsx
+++ b/src/components/popularity/Popularity.tsx
@@ -3,7 +3,7 @@ import StackedAreaChart from "./StackedAreaChart"
 
 const Popularity = async() => {
 
-  const response = await fetch(`http://localhost:3000/api/popularity/countSteamReviews/1172470`);
+  const response = await fetch(`${process.env.CURRENT_URL}/api/popularity/countSteamReviews/1172470`);
   const data = await response.json();
 
   return (

--- a/src/components/simlarGames/SimilarGames.tsx
+++ b/src/components/simlarGames/SimilarGames.tsx
@@ -4,7 +4,7 @@ import { GameDetails } from "@/types/similarGames/GameDetails";
 
 const SimilarGames = async() => {
 
-  const res = await fetch('http://localhost:3000/api/similarGames/gameDetails')
+  const res = await fetch(`${process.env.CURRENT_URL}/api/similarGames/gameDetails`)
   const data = await res.json()
 
   return (

--- a/src/types/api/gameDetailsType.ts
+++ b/src/types/api/gameDetailsType.ts
@@ -1,18 +1,4 @@
-export type steamGameCategoryType = {
-  id: number,
-  description: string
-}
-
-export type steamGameGenreType = {
-  id: string,
-  description: string
-}
-
-export type steamGamePlatformType = {
-  windows: boolean,
-  mac: boolean,
-  linux: boolean
-}
+import { steamGamePlatformType } from "./steamDataType"
 
 export type gameDetailType = {
   twitchGameId: string,

--- a/src/types/api/getGameDetailsType.ts
+++ b/src/types/api/getGameDetailsType.ts
@@ -1,0 +1,29 @@
+export type steamGameCategoryType = {
+  id: number,
+  description: string
+}
+
+export type steamGameGenreType = {
+  id: string,
+  description: string
+}
+
+export type steamGamePlatformType = {
+  windows: boolean,
+  mac: boolean,
+  linux: boolean
+}
+
+export type gameDetailType = {
+  twitchGameId: string,
+  steamGameId: string,
+  title: string,
+  imgURL: string,
+  gameData: {
+    genres : string[],
+    price: number,
+    isSinglePlayer: boolean,
+    isMultiPlayer: boolean,
+    platforms: steamGamePlatformType,
+  }
+}

--- a/src/types/api/steamDataType.ts
+++ b/src/types/api/steamDataType.ts
@@ -1,0 +1,15 @@
+export type steamGameCategoryType = {
+  id: number,
+  description: string
+}
+
+export type steamGameGenreType = {
+  id: string,
+  description: string
+}
+
+export type steamGamePlatformType = {
+  windows: boolean,
+  mac: boolean,
+  linux: boolean
+}


### PR DESCRIPTION
- api/networkに初期読み込み時のデータ取得のAPI実装
- api/getMatchDetails/x/y でxにsteamId, yにtwitchIdで呼びだす
上記の取得で得れる値は下のとおり
```
[
    {
        twitchGameID  : string
        SteamGameID   : string
        title         : string
        imgURL        : string
        gameData : {
           genres                 :  []
           price                  :  number
           isSinglePlayer         :  boolean
           isMultiPlayer          :  boolean
        }
    },
]
```
- localhostで書いてたのも修正しました