### PR TITLE
価格フィルターを中心とした変更

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "react-hooks/exhaustive-deps": "off"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "swr": "^2.2.5"
       },
       "devDependencies": {
+        "@types/d3": "^7.4.3",
         "@types/node": "^20",
         "@types/pg": "^8.11.6",
         "@types/react": "^18",
@@ -1127,20 +1128,134 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
       "integrity": "sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ=="
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "dev": true
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA=="
     },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/d3-delaunay": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
       "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ=="
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.6.tgz",
+      "integrity": "sha512-4fvZhzMeeuBJYZXRXrRIQnvUYfyXwYmLsdiN7XXmVNQKKw1cM8a5WdID0g1hVFZDqT9ZqZEY5pD44p24VS7iZQ==",
+      "dev": true
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "dev": true
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "dev": true
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true
     },
     "node_modules/@types/d3-format": {
       "version": "3.0.1",
@@ -1155,6 +1270,12 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "dev": true
+    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
@@ -1168,6 +1289,18 @@
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.11.tgz",
       "integrity": "sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw=="
     },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "dev": true
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "dev": true
+    },
     "node_modules/@types/d3-random": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-2.2.3.tgz",
@@ -1180,6 +1313,18 @@
       "dependencies": {
         "@types/d3-time": "*"
       }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.3.tgz",
+      "integrity": "sha512-laXM4+1o5ImZv3RpFAsTRn3TEkzqkytiOY0Dz0sq5cnd1dtNlk6sHLon4OvqaiJb28T0S/TdsBI3Sjsy+keJrw==",
+      "dev": true
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.10.tgz",
+      "integrity": "sha512-cuHoUgS/V3hLdjJOLTT691+G2QoqAjCVLmr4kJXR4ha56w1Zdu8UUQ5TxLRqudgNjwXeQxKMq4j+lyf9sWuslg==",
+      "dev": true
     },
     "node_modules/@types/d3-shape": {
       "version": "1.3.12",
@@ -1198,6 +1343,31 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.0.tgz",
       "integrity": "sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "dev": true
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.8.tgz",
+      "integrity": "sha512-ew63aJfQ/ms7QQ4X7pk5NxQ9fZH/z+i24ZfJ6tJSfqxJMrYLiK01EAs2/Rtw/JreGUsS3pLPNV644qXFGnoZNQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.14",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "swr": "^2.2.5"
   },
   "devDependencies": {
+    "@types/d3": "^7.4.3",
     "@types/node": "^20",
     "@types/pg": "^8.11.6",
     "@types/react": "^18",

--- a/src/app/api/details/getSteamGameDetail/[steamGameId]/route.ts
+++ b/src/app/api/details/getSteamGameDetail/[steamGameId]/route.ts
@@ -22,10 +22,9 @@ export async function GET(req: Request, {params}: Params) {
     price: gameDetailData.price_overview ? gameDetailData.price_overview.final / 100 : 0,
     isSinglePlayer: gameDetailData.categories.some((category: steamGameCategoryType) => category.id === 2),
     isMultiPlayer: gameDetailData.categories.some((category: steamGameCategoryType) => category.id === 1),
-    platforms: {
+    device: {
       windows: gameDetailData.platforms.windows,
       mac: gameDetailData.platforms.mac,
-      linux: gameDetailData.platforms.linux
     }
   }
 

--- a/src/app/api/network/getMatchGames/route.ts
+++ b/src/app/api/network/getMatchGames/route.ts
@@ -48,13 +48,12 @@ export async function GET() {
         totalViews: total_views,
         gameData: {
           genres: gameDetailData.genres,
-          price: gameDetailData.price_overview ? gameDetailData.price_overview.final : 0,
+          price: gameDetailData.price_overview ? gameDetailData.price_overview.final / 100 : 0,
           isSinglePlayer: gameDetailData.categories.some((category: steamGameCategoryType) => category.id === 2),
           isMultiPlayer: gameDetailData.categories.some((category: steamGameCategoryType) => category.id === 1),
-          platforms: {
+          device: {
             windows: gameDetailData.platforms.windows,
             mac: gameDetailData.platforms.mac,
-            linux: gameDetailData.platforms.linux
           }
         }
       })

--- a/src/app/api/network/getMatchGames/route.ts
+++ b/src/app/api/network/getMatchGames/route.ts
@@ -1,11 +1,10 @@
 import { PG_POOL } from "@/constants/PG_POOL";
+import { gameDetailType } from "@/types/api/gameDetailsType";
 import { steamGameCategoryType } from "@/types/api/steamDataType";
 import { NextResponse } from "next/server";
 
 export async function GET() {
-
   try {
-
     const today = new Date();
     today.setDate(today.getDate() -1);
     const dateString = today.toISOString().split('T')[0];
@@ -26,12 +25,12 @@ export async function GET() {
                           ))
                         ));
 
-    const result = [];
+    const result: gameDetailType[] = [];
     for(let i = 0; i < data.length; i += 1) {
 
       const twitchGameId = data[i].twitch_id;
       const steamGameId = data[i].steam_id;
-
+      const total_views = data[i].total_views;
 
       const response = await fetch(`https://store.steampowered.com/api/appdetails?appids=${steamGameId}&cc=jp`);
       const responseJson = await response.json();
@@ -46,6 +45,7 @@ export async function GET() {
         steamGameId: steamGameId,
         title: gameDetailData.name,
         imgURL: gameDetailData.header_image,
+        totalViews: total_views,
         gameData: {
           genres: gameDetailData.genres,
           price: gameDetailData.price_overview ? gameDetailData.price_overview.final : 0,
@@ -59,7 +59,6 @@ export async function GET() {
         }
       })
     }
-    
 
     return NextResponse.json(result);
 

--- a/src/components/match/Match.tsx
+++ b/src/components/match/Match.tsx
@@ -17,7 +17,7 @@ const Match = async(props:Props) => {
     <div>
       <Headline txt='フィルター項目との一致度'/>
       {data ? (
-        <MatchIndicator data={data}/>
+        <MatchIndicator data={data} />
       ) : null}
     </div>
   )

--- a/src/components/match/MatchIndicator.tsx
+++ b/src/components/match/MatchIndicator.tsx
@@ -57,7 +57,6 @@ const MatchIndicator: React.FC<MatchIndicatorProps> = ({ data }) => {
   const [genreMatchPercentage, setGenreMatchPercentage] = useState<number>(0);
   const [priceMatchPercentage, setPriceMatchPercentage] = useState<number>(0);
   const [modeMatchPercentage, setModeMatchPercentage] = useState<number>(0);
-  const [priceDifference, setPriceDifference] = useState<number>(0);
   const [overallMatchPercentage, setOverallMatchPercentage] = useState<number>(0);
 
   useEffect(() => {
@@ -65,10 +64,6 @@ const MatchIndicator: React.FC<MatchIndicatorProps> = ({ data }) => {
     const genreMatchCount = countMatchingGenres();
     const genreMatch = calculateMatchPercentage(genreMatchCount, data.genres.length);
     setGenreMatchPercentage(genreMatch);
-
-    // 価格の差分を計算
-    const priceDiff = data.price - calculateUserSelectedPrice();
-    setPriceDifference(priceDiff);
 
     // 一致度を計算(価格)
     const priceMatch = calculateMatchPercentage(data.price, calculateUserSelectedPrice());
@@ -131,10 +126,6 @@ const MatchIndicator: React.FC<MatchIndicatorProps> = ({ data }) => {
     return price;
   };
 
-  const getTextColor = (percentage: number, barColor: string) => {
-    return percentage > 50 ? 'text-white' : barColor;
-  };
-
   return (
     <div className='text-white'>
       <div className="mb-4">
@@ -146,7 +137,6 @@ const MatchIndicator: React.FC<MatchIndicatorProps> = ({ data }) => {
           </div>
         </div>
       </div>
-
 
       <div className="mb-4">
         <p className="text-lg">ジャンル一致度</p>

--- a/src/components/match/d3.d.ts
+++ b/src/components/match/d3.d.ts
@@ -1,0 +1,1 @@
+declare module "d3";

--- a/src/components/match/d3.d.ts
+++ b/src/components/match/d3.d.ts
@@ -1,1 +1,0 @@
-declare module "d3";

--- a/src/components/network/Icon.tsx
+++ b/src/components/network/Icon.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useRouter } from 'next/navigation';
 
 const Icon = (props:any) => {
-  const { title, imgURL, index, steamGameId, twitchGameId } = props;
+  const { title, imgURL, index, steamGameId, twitchGameId, circleScale } = props;
   const [isHovered, setIsHovered] = useState(false);
   const router = useRouter();
   const handleClick = (e:any) => {
@@ -15,8 +15,7 @@ const Icon = (props:any) => {
     <g
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      transform={`scale(1.5)`}
-      /* transform={`scale(${circleSize})`} */
+      transform={`scale(${circleScale})`}
       style={{ cursor: "pointer" }}
       onClick={handleClick}
     >

--- a/src/components/network/Network.tsx
+++ b/src/components/network/Network.tsx
@@ -38,25 +38,16 @@ const Network = () => {
       84: true,
     },
     Price: {
-      1: true,
-      2: true,
-      3: true,
-      4: true,
-      5: true,
-      6: true,
-      7: true,
-      8: true,
-      9: true,
-      10: true,
-      11: true,
+      startPrice: 0,
+      endPrice: 10000
     },
-    Platforms: {
-      1: true,
-      2: true,
+    Mode: {
+      isSinglePlayer: true,
+      isMultiPlayer: true
     },
-    device: {
-      1: true,
-      2: true,
+    Device: {
+        windows: true,
+        mac: true
     },
     Playtime: {
       1: true,

--- a/src/components/network/NodeLink.tsx
+++ b/src/components/network/NodeLink.tsx
@@ -5,7 +5,7 @@ import * as d3 from 'd3';
 import Icon from "./Icon";
 import createNetwork from "@/hooks/createNetwork";
 
-const ZoomableSVG = (props:any) => {
+const ZoomableSVG = (props: any) => {
   const { children } = props;
 
   const svgRef = useRef<SVGSVGElement>(null);
@@ -14,14 +14,17 @@ const ZoomableSVG = (props:any) => {
   const [y, setY] = useState(0);
 
   useEffect(() => {
-    const zoom = d3.zoom().on("zoom", (event:any) => {
+    const zoom = d3.zoom<SVGSVGElement, unknown>().on("zoom", (event: d3.D3ZoomEvent<SVGSVGElement, unknown>) => {
       const { x, y, k } = event.transform;
       setX(x);
       setY(y);
       setK(k);
     });
-    d3.select(svgRef.current).call(zoom);
+    if (svgRef.current) {
+      d3.select<SVGSVGElement, unknown>(svgRef.current).call(zoom);
+    }
   }, []);
+
   return (
     <svg ref={svgRef} width={window.innerWidth} height={window.innerHeight}>
       <g transform={`translate(${x + 300},${y + 200})scale(${k - 0.5})`}>
@@ -31,7 +34,7 @@ const ZoomableSVG = (props:any) => {
   );
 };
 
-const NodeLink = (props:any) => {
+const NodeLink = (props: any) => {
   const { filter } = props;
 
   const [nodes, setNodes] = useState<any>([]);
@@ -41,19 +44,19 @@ const NodeLink = (props:any) => {
 
   useEffect(() => {
     (async () => {
-      const {nodes, links} = await createNetwork();
+      const { nodes, links } = await createNetwork();
       setNodes(nodes);
       setLinks(links);
       setIsLoading(false);
     })();
-    
+
   }, [filter]);
 
   return (
     <div>
       {!isLoading ? <ZoomableSVG>
         {links.length !== 0 &&
-          links.map((link:any, i) => (
+          links.map((link: any, i) => (
             <line
               key={i}
               className="link"
@@ -65,7 +68,7 @@ const NodeLink = (props:any) => {
             />
           ))}
         {nodes.length !== 0 &&
-          nodes.map((node:any, i:any) => {
+          nodes.map((node: any, i: any) => {
             return (
               <g transform={`translate(${node.x},${node.y})`} key={i}>
                 <Icon

--- a/src/components/network/NodeLink.tsx
+++ b/src/components/network/NodeLink.tsx
@@ -74,6 +74,7 @@ const NodeLink = (props:any) => {
                   index={node.index}
                   steamGameId={node.steamGameId}
                   twitchGameId={node.twitchGameId}
+                  circleScale={node.circleScale}
                 ></Icon>
               </g>
             );

--- a/src/components/network/SelectParameter.tsx
+++ b/src/components/network/SelectParameter.tsx
@@ -37,27 +37,18 @@ const genreMapping: any = {
 };
 
 const priceMapping: any = {
-  1: "無料プレイ",
-  2: "～1000円",
-  3: "～2000円",
-  4: "～3000円",
-  5: "～4000円",
-  6: "～5000円",
-  7: "～6000円",
-  8: "～7000円",
-  9: "～8000円",
-  10: "～9000円",
-  11: "～10000円"
+  startPrice: 0,
+  endPrice: 10000
 };
 
-const platformsMapping: any = {
-  1: "1人用",
-  2: "マルチ用",
+const modeMapping: any = {
+  isSinglePlayer: "シングルプレイヤー",
+  isMultiPlayer: "マルチプレイヤー"
 };
 
 const deviceMapping: any = {
-  1: "windows",
-  2: "mac",
+  windows: "windows",
+  mac: "mac"
 };
 
 const playtimeMapping: any = {
@@ -124,7 +115,6 @@ const SliderFilter = ({ min, max, values, onChange, valueFormatter, disabled }: 
 
 const Dropdown = ({ displayTag, title, mapping, isVisible, toggleVisibility, localFilter, setLocalFilter }: { displayTag:string, title: string, mapping: any, isVisible: boolean, toggleVisibility: () => void, localFilter: any, setLocalFilter: any }) => {
   const contentRef = useRef<HTMLDivElement>(null);
-  const w = title === "Categories" ? 3 : 2;
 
   const handleChangeFilter = (key: number) => {
     setLocalFilter((prev:any) => {
@@ -159,18 +149,18 @@ const Dropdown = ({ displayTag, title, mapping, isVisible, toggleVisibility, loc
       });
     };
 
-    const handleDeselectAll = () => {
-      setLocalFilter((prev: any) => {
-        const newFilter = { ...prev[title] };
-        Object.keys(mapping).forEach((key) => {
-          newFilter[key] = false;
-        });
-        return {
-          ...prev,
-          [title]: newFilter,
-        };
+  const handleDeselectAll = () => {
+    setLocalFilter((prev: any) => {
+      const newFilter = { ...prev[title] };
+      Object.keys(mapping).forEach((key) => {
+        newFilter[key] = false;
       });
-    };
+      return {
+        ...prev,
+        [title]: newFilter,
+      };
+    });
+  };
 
 
   return (
@@ -194,48 +184,37 @@ const Dropdown = ({ displayTag, title, mapping, isVisible, toggleVisibility, loc
         }}
       >
 
-      {title=="Categories" ? <div className="p-2">
-          <button
-            onClick={handleSelectAll}
-            className="bg-blue-600 hover:bg-blue-500 text-white rounded px-4 py-2 mr-2"
-          >
-            全選択
-          </button>
-          <button
-            onClick={handleDeselectAll}
-            className="bg-red-600 hover:bg-red-500 text-white rounded px-4 py-2"
-          >
-            全解除
-          </button>
-        </div>: null}
+        {title=="Categories" ? <div className="p-2">
+            <button
+              onClick={handleSelectAll}
+              className="bg-blue-600 hover:bg-blue-500 text-white rounded px-4 py-2 mr-2"
+            >
+              全選択
+            </button>
+            <button
+              onClick={handleDeselectAll}
+              className="bg-red-600 hover:bg-red-500 text-white rounded px-4 py-2"
+            >
+              全解除
+            </button>
+          </div>: null}
 
-      <div className="flex flex-wrap -mx-2 p-2">
-        {Object.keys(mapping).map((key: any) => {
-          const flag = localFilter[title][key];
-          return (
-            <div key={key} className="w-1/2 p-2">
-              <button 
-                onClick={() => handleChangeFilter(key)} 
-                className={`${flag ? 'bg-blue-900 hover:bg-blue-800' : 'bg-gray-800 hover:bg-gray-700'} text-white rounded px-2 py-2 w-full h-10 overflow-hidden text-sm`}
-              >
-                <span className="block truncate">{mapping[key]}</span>
-              </button>
-            </div>
-          );
-        })}
-      </div>
-        {/* <div className="flex flex-wrap -mx-2 p-2">
+        <div className="flex flex-wrap -mx-2 p-2">
           {Object.keys(mapping).map((key: any) => {
             const flag = localFilter[title][key];
-            return <div key={key} className={`w-1/${w} p-2`}>
-              {flag ? <button onClick={() => handleChangeFilter(key)} className="bg-blue-900 hover:bg-blue-800 text-white rounded px-4 py-2 w-full h-12 overflow-hidden text-lg">
-                <span className="block truncate">{mapping[key]}</span>
-              </button> : <button onClick={() => handleChangeFilter(key)} className="bg-gray-800 hover:bg-gray-700 text-white rounded px-4 py-2 w-full h-12 overflow-hidden text-lg">
-                <span className="block truncate">{mapping[key]}</span>
-              </button>}
-            </div>
+            return (
+              <div key={key} className="w-1/2 p-2">
+                <button 
+                  onClick={() => handleChangeFilter(key)} 
+                  className={`${flag ? 'bg-blue-900 hover:bg-blue-800' : 'bg-gray-800 hover:bg-gray-700'} text-white rounded px-2 py-2 w-full h-10 overflow-hidden text-sm`}
+                >
+                  <span className="block truncate">{mapping[key]}</span>
+                </button>
+              </div>
+            );
           })}
-        </div> */}
+        </div>
+
       </div>
     </div>
   );
@@ -247,7 +226,7 @@ const SelectParameter = (props: any) => {
 
   const [localFilter, setLocalFilter] = useState(filter);
   const [isFreeChecked, setIsFreeChecked] = useState(false);
-  const [priceRange, setPriceRange] = useState<number[]>([0, 11]);
+  const [priceRange, setPriceRange] = useState<number[]>([0, 10000]);
   const [playtimeRange, setPlaytimeRange] = useState<number[]>([0, 10]);
 
   const toggleDropdown = (dropdown: string) => {
@@ -255,16 +234,14 @@ const SelectParameter = (props: any) => {
   };
 
   const handlePriceChange = (values: number[]) => {
-    setPriceRange(values);
-    const newFilter = { ...localFilter };
-    for (let key in priceMapping) {
-      const priceLevel = parseInt(key);
-      if (priceLevel >= values[0] + 1 && priceLevel <= values[1]) {
-        newFilter['Price'][key] = true;
-      } else {
-        newFilter['Price'][key] = false;
+    const newFilter = {
+      ...localFilter,
+      Price: {
+        startPrice: values[0],
+        endPrice: values[1]
       }
-    }
+    };
+    setPriceRange(values);
     setLocalFilter(newFilter);
   };
 
@@ -298,6 +275,7 @@ const SelectParameter = (props: any) => {
       if(d) {
         setFilter(d);
         setLocalFilter(d);
+        setPriceRange([d.Price.startPrice, d.Price.endPrice]);
       }
     })();
   }, [])
@@ -363,76 +341,36 @@ const SelectParameter = (props: any) => {
                   </label>
               </div>
               <SliderFilter
-                min={1}
-                max={11}
+                min={0}
+                max={10000}
                 values={priceRange}
                 onChange={handlePriceChange}
-                valueFormatter={(value) => (value === 1 ? '1円' : `${(value-1) * 1000}円`)}
+                valueFormatter={(value) => (value === 1 ? '1円' : `${(value)}円`)}
                 disabled={isFreeChecked}
               />
             </div>
           </div>
         )}
       </div>
-      {/* <Dropdown
-        title="Price"
-        mapping={priceMapping}
-        isVisible={visibleDropdown === "Price"}
-        toggleVisibility={() => toggleDropdown("Price")}
-        localFilter={localFilter}
-        setLocalFilter={setLocalFilter}
-      /> */}
       <Dropdown
-        displayTag = "プラットフォーム"
-        title="Platforms"
-        mapping={platformsMapping}
-        isVisible={visibleDropdown === "Platforms"}
-        toggleVisibility={() => toggleDropdown("Platforms")}
+        displayTag = "モード"
+        title="Mode"
+        mapping={modeMapping}
+        isVisible={visibleDropdown === "Mode"}
+        toggleVisibility={() => toggleDropdown("Mode")}
         localFilter={localFilter}
         setLocalFilter={setLocalFilter}
       />
 
       <Dropdown
         displayTag = "対応デバイス"
-        title="device"
+        title="Device"
         mapping={deviceMapping}
-        isVisible={visibleDropdown === "device"}
-        toggleVisibility={() => toggleDropdown("device")}
+        isVisible={visibleDropdown === "Device"}
+        toggleVisibility={() => toggleDropdown("Device")}
         localFilter={localFilter}
         setLocalFilter={setLocalFilter}
       />
-      {/* <div className="relative mb-4">
-        <button
-          className="bg-gray-900 hover:bg-gray-800 text-white rounded px-4 py-2 mb-2 flex items-center justify-between w-full"
-          onClick={() => toggleDropdown("Playtime")}
-        >
-          プレイ時間
-          <span className="ml-2">{visibleDropdown === 'Playtime' ? '▲' : '▼'}</span>
-        </button>
-        {visibleDropdown === 'Playtime' && (
-          <div className="rounded mt-1 w-full z-10 overflow-hidden">
-            <div className="p-4 text-white">
-              <SliderFilter
-                min={0}
-                max={10}
-                values={playtimeRange}
-                onChange={handlePlaytimeChange}
-                valueFormatter={(value) => `${(value) * 100}時間`}
-                disabled={false}
-              />
-            </div>
-          </div>
-        )}
-      </div> */}
-      {/* <Dropdown
-        displayTag = "プレイ時間"
-        title="Playtime"
-        mapping={playtimeMapping}
-        isVisible={visibleDropdown === "Playtime"}
-        toggleVisibility={() => toggleDropdown("Playtime")}
-        localFilter={localFilter}
-        setLocalFilter={setLocalFilter}
-      /> */}
     </div>
   );
 };

--- a/src/components/network/d3.d.ts
+++ b/src/components/network/d3.d.ts
@@ -1,1 +1,0 @@
-declare module "d3";

--- a/src/constants/DEFAULT_FILTER.ts
+++ b/src/constants/DEFAULT_FILTER.ts
@@ -32,26 +32,16 @@ export const DEFAULT_FILTER = {
       "84": true
   },
   "Price": {
-      "0": true,
-      "1": true,
-      "2": true,
-      "3": true,
-      "4": true,
-      "5": true,
-      "6": true,
-      "7": true,
-      "8": true,
-      "9": true,
-      "10": true,
-      "11": true
+    "startPrice": 0,
+    "endPrice": 10000
   },
-  "Platforms": {
-      "1": true,
-      "2": true
+  "Mode": {
+      "isSinglePlayer": true,
+      "isMultiPlayer": true
   },
-  "device": {
-      "1": true,
-      "2": true
+  "Device": {
+      "windows": true,
+      "mac": true
   },
   "Playtime": {
       "1": true,

--- a/src/hooks/createNetwork.ts
+++ b/src/hooks/createNetwork.ts
@@ -78,8 +78,10 @@ const createNetwork = async () => {
         links.filter((item:any) => item.target === index || item.source === index)
           .length < k;
       if (count < k && isSourceOk && isTargetOk) {
-        links.push({ source: i, target: index });
-        count++;
+        if (i !== index) {
+          links.push({ source: i, target: index });
+          count++;
+        }
         if (
           links.filter((item:any) => item.target === i || item.source === i)
             .length >= k
@@ -112,28 +114,39 @@ const createNetwork = async () => {
 
   simulation.tick(300).stop()
 
+  /* const newLinks = links.map((link:any) => {
+    return {source:link.source.steamGameId, target:link.target.steamGameId}
+  });
+
+  console.log(newLinks); */
+
+  nodes.forEach((node: any) => {
+    similarGames[node.steamGameId] = [];
+  })
+
   links.forEach((link: any) => {
     const sourceGame = link.source;
     const targetGame = link.target;
 
-    if(sourceGame === targetGame) return ;
-
-    if(similarGames[sourceGame.steamGameId]) {
-      if(!similarGames[sourceGame.steamGameId].includes({steamGameId: targetGame.steamGameId, twitchGameId: targetGame.twitchGameId})) {
-        similarGames[sourceGame.steamGameId].push({steamGameId: targetGame.steamGameId, twitchGameId: targetGame.twitchGameId});
-      }
-    } else {
-      similarGames[sourceGame.steamGameId] = [{steamGameId: targetGame.steamGameId, twitchGameId: targetGame.twitchGameId}];
+    const isSourceGameIncluded = similarGames[sourceGame.steamGameId].some((game:any) => 
+      game.steamGameId === targetGame.steamGameId && targetGame.twitchGameId === targetGame.twitchGameId
+    );
+    if(!isSourceGameIncluded) {
+      similarGames[sourceGame.steamGameId].push({steamGameId: targetGame.steamGameId, twitchGameId: targetGame.twitchGameId});
     }
 
-    if(similarGames[targetGame.steamGameId]) {
-      if(!similarGames[targetGame.steamGameId].includes({steamGameId: sourceGame.steamGameId, twitchGameId: sourceGame.twitchGameId})) {
-        similarGames[targetGame.steamGameId].push({steamGameId: sourceGame.steamGameId, twitchGameId: sourceGame.twitchGameId});
-      }
-    } else {
-      similarGames[targetGame.steamGameId] = [{steamGameId: sourceGame.steamGameId, twitchGameId: sourceGame.twitchGameId}];
+
+   
+    const isTargetGameIncluded = similarGames[targetGame.steamGameId].some((game:any) => 
+      game.steamGameId === sourceGame.steamGameId && game.twitchGameId === sourceGame.twitchGameId
+    );
+    if(!isTargetGameIncluded) {
+      similarGames[targetGame.steamGameId].push({steamGameId: sourceGame.steamGameId, twitchGameId: sourceGame.twitchGameId});
     }
+
   });
+
+  console.log(similarGames);
 
   return {nodes, links, similarGames};
 };

--- a/src/hooks/createNetwork.ts
+++ b/src/hooks/createNetwork.ts
@@ -114,12 +114,6 @@ const createNetwork = async () => {
 
   simulation.tick(300).stop()
 
-  /* const newLinks = links.map((link:any) => {
-    return {source:link.source.steamGameId, target:link.target.steamGameId}
-  });
-
-  console.log(newLinks); */
-
   nodes.forEach((node: any) => {
     similarGames[node.steamGameId] = [];
   })
@@ -134,8 +128,6 @@ const createNetwork = async () => {
     if(!isSourceGameIncluded) {
       similarGames[sourceGame.steamGameId].push({steamGameId: targetGame.steamGameId, twitchGameId: targetGame.twitchGameId});
     }
-
-
    
     const isTargetGameIncluded = similarGames[targetGame.steamGameId].some((game:any) => 
       game.steamGameId === sourceGame.steamGameId && game.twitchGameId === sourceGame.twitchGameId
@@ -145,8 +137,6 @@ const createNetwork = async () => {
     }
 
   });
-
-  console.log(similarGames);
 
   return {nodes, links, similarGames};
 };

--- a/src/hooks/d3.d.ts
+++ b/src/hooks/d3.d.ts
@@ -1,1 +1,0 @@
-declare module "d3";

--- a/src/hooks/indexedDB.ts
+++ b/src/hooks/indexedDB.ts
@@ -1,3 +1,5 @@
+import { Filter } from "@/types/api/FilterType";
+
 let db: IDBDatabase;
 let dbInitialized: Promise<IDBDatabase>;
 
@@ -12,7 +14,7 @@ if (typeof window !== 'undefined') {
       networkFilterStore.createIndex('Categories', 'Categories', { unique: false });
       networkFilterStore.createIndex('Price', 'Price', { unique: false });
       networkFilterStore.createIndex('Platforms', 'Platforms', { unique: false });
-      networkFilterStore.createIndex('device', 'device', { unique: false });
+      networkFilterStore.createIndex('Device', 'Device', { unique: false });
       networkFilterStore.createIndex('Playtime', 'Playtime', { unique: false });
     }
   };
@@ -41,14 +43,7 @@ if (typeof window !== 'undefined') {
   });
 }
 
-export async function addFilterData(data: {
-  id: string;
-  Categories: { [key: string]: boolean };
-  Price: { [key: string]: boolean };
-  Platforms: { [key: string]: boolean };
-  device: { [key: string]: boolean };
-  Playtime: { [key: string]: boolean };
-}) {
+export async function addFilterData(data: Filter) {
   if (typeof window === 'undefined') return;
 
   const db = await dbInitialized;
@@ -65,14 +60,7 @@ export async function addFilterData(data: {
   };
 }
 
-export async function getFilterData(key: string): Promise<{
-  id: string;
-  Categories: { [key: string]: boolean };
-  Price: { [key: string]: boolean };
-  Platforms: { [key: string]: boolean };
-  device: { [key: string]: boolean };
-  Playtime: { [key: string]: boolean };
-} | null> {
+export async function getFilterData(key: string): Promise<Filter | null> {
   if (typeof window === 'undefined') return null;
 
   const db = await dbInitialized;
@@ -99,14 +87,7 @@ export async function getFilterData(key: string): Promise<{
   });
 }
 
-export async function updateFilterData(data: {
-  id: string;
-  Categories: { [key: string]: boolean };
-  Price: { [key: string]: boolean };
-  Platforms: { [key: string]: boolean };
-  device: { [key: string]: boolean };
-  Playtime: { [key: string]: boolean };
-}) {
+export async function updateFilterData(data: Filter) {
   if (typeof window === 'undefined') return;
 
   const db = await dbInitialized;

--- a/src/types/api/FilterType.ts
+++ b/src/types/api/FilterType.ts
@@ -1,0 +1,14 @@
+export type Filter = {
+  id: string;
+  Categories: { [key: string]: boolean };
+  Price: { startPrice: number, endPrice: number };
+  Mode: {
+    isSinglePlayer: boolean,
+    isMultiPlayer: boolean
+  };
+  Device: {
+      windows: boolean,
+      mac: boolean
+  };
+  Playtime: { [key: string]: boolean };
+}

--- a/src/types/api/gameDetailsType.ts
+++ b/src/types/api/gameDetailsType.ts
@@ -1,4 +1,4 @@
-import { steamGamePlatformType } from "./steamDataType"
+import { steamGameDeviceType} from "./steamDataType"
 
 export type gameDetailType = {
   twitchGameId: string,
@@ -11,6 +11,6 @@ export type gameDetailType = {
     price: number,
     isSinglePlayer: boolean,
     isMultiPlayer: boolean,
-    platforms: steamGamePlatformType,
+    device: steamGameDeviceType,
   }
 }

--- a/src/types/api/gameDetailsType.ts
+++ b/src/types/api/gameDetailsType.ts
@@ -5,6 +5,7 @@ export type gameDetailType = {
   steamGameId: string,
   title: string,
   imgURL: string,
+  totalViews: number,
   gameData: {
     genres : string[],
     price: number,

--- a/src/types/api/steamDataType.ts
+++ b/src/types/api/steamDataType.ts
@@ -8,8 +8,7 @@ export type steamGameGenreType = {
   description: string
 }
 
-export type steamGamePlatformType = {
+export type steamGameDeviceType = {
   windows: boolean,
   mac: boolean,
-  linux: boolean
 }

--- a/src/types/match/MatchDataType.ts
+++ b/src/types/match/MatchDataType.ts
@@ -4,7 +4,7 @@ export type MatchDataType = {
   price: number;
   isSinglePlayer: boolean;
   isMultiPlayer: boolean;
-  platforms: PlatformsType
+  device: DeviceType;
 };
 
 export type GenreType = {
@@ -12,8 +12,7 @@ export type GenreType = {
   description: string;
 };
 
-export type PlatformsType = {
+export type DeviceType = {
   windows: boolean;
   mac: boolean;
-  linux: boolean;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "downlevelIteration": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
- 一致度を価格・デバイス込みで計算するようにした
- それに伴い一致度の計算方法を見直した
- 一致度を小数点第一位まで表示するようにした、もしも整数の方が見やすかったら変えてもいい
- ノードの大きさを上記の一致度に応じて変化するようにした、これによりフィルター機能をいじるとノードの大きさが変わる
- 価格のフィルタースライダーを1円単位で動かすように変更した、無料ボタンの対応は忘れてたので多分後でやる
- シングルプレイヤー・マルチプレイヤーのコード上の表記をmode、windows・macのコード上の表記をdeviceにした
- これらの変更をindexedDBにも反映した、indexedDBの初期化をいったんしてもらった方がいいかも
- 今回変更した範囲で目についたところのリファクタリングをした