### PR TITLE
[add]ラベルを日本語に対応

### DIFF
--- a/src/app/api/details/getTwitchViews/[gameId]/route.ts
+++ b/src/app/api/details/getTwitchViews/[gameId]/route.ts
@@ -34,7 +34,9 @@ export async function GET(req: Request, params: Params) {
         date: unixTime,
         count: d.total_views
       }
-    })
+    }).sort((d1, d2) => d1.date - d2.date);
+
+    console.log(formatData);
 
     return NextResponse.json(formatData)
 

--- a/src/app/api/details/getTwitchViews/[gameId]/route.ts
+++ b/src/app/api/details/getTwitchViews/[gameId]/route.ts
@@ -36,8 +36,6 @@ export async function GET(req: Request, params: Params) {
       }
     }).sort((d1, d2) => d1.date - d2.date);
 
-    console.log(formatData);
-
     return NextResponse.json(formatData)
 
   } catch (error) {

--- a/src/components/match/MatchIndicator.tsx
+++ b/src/components/match/MatchIndicator.tsx
@@ -119,7 +119,8 @@ const MatchIndicator: React.FC<MatchIndicatorProps> = ( props ) => {
   }
 
   const priceBarPosition = (price: number) => {
-    const maxPrice = calculateUserSelectedPrice() === 0 ? 1000 : calculateUserSelectedPrice() * 2;
+    // const maxPrice = calculateUserSelectedPrice() === 0 ? 1000 : calculateUserSelectedPrice() * 2;
+    const maxPrice = 10000;
     const adjustedPrice = Math.min(price, maxPrice);
     return (adjustedPrice / maxPrice) * 100;
   };
@@ -130,6 +131,16 @@ const MatchIndicator: React.FC<MatchIndicatorProps> = ( props ) => {
       price = index === 0 ? 0 : (index + 1) * 1000;
     });
     return price;
+  };
+
+  const calculateRangePosition = (startPrice: number, endPrice: number) => {
+    const maxPrice = 10000;
+    const start = Math.min(startPrice, maxPrice);
+    const end = Math.min(endPrice, maxPrice);
+    return {
+      startPosition: (start / maxPrice) * 100,
+      endPosition: (end / maxPrice) * 100,
+    };
   };
 
   return (
@@ -154,9 +165,9 @@ const MatchIndicator: React.FC<MatchIndicatorProps> = ( props ) => {
         </div>
         <div className="w-full bg-gray-300 rounded-b-lg pt-0 pb-1 pl-2 pr-1 ">
           {data.genres.map((genre) => (
-            <small key={genre.id} className="text-gray-700">
-              {genre.description}&nbsp;
-            </small>
+            <div key={genre.id} className="inline-block bg-white text-gray-700 rounded-md px-2 py-0 my-0.5 cursor-pointer">
+              <small>{genre.description}</small>
+            </div>
           ))}
         </div>
       </div>
@@ -173,38 +184,28 @@ const MatchIndicator: React.FC<MatchIndicatorProps> = ( props ) => {
                     width: `${priceBarPosition(data.price)}%`,
                   }}
                 ></div>
-                 {Object.keys(localFilter.Price).map((key) => {
-                    const minPrice = Math.max((Number(key) - 2), 0) * 1000;
-                    const maxPrice = Math.min((Number(key) - 1), 10) * 1000;
-
-                    // バーの位置と幅を計算
-                    const barWidth = (maxPrice - minPrice) / (calculateUserSelectedPrice() * 2) * 100;
-                    const barLeft = (minPrice / (calculateUserSelectedPrice() * 2)) * 100;
-
-                    return (
-                      <div
-                        key={key}
-                        className="absolute top-0 left-0 h-full"
-                        style={{
-                          width: `${barWidth}%`,
-                          left: `${barLeft}%`,
-                          backgroundColor: 'rgba(0, 165, 0, 0.5)',
-                        }}
-                      ></div>
-                    );
-                })}
+                <div
+                  className="absolute top-0 h-full rounded-lg bg-orange-800/20"
+                  style={{
+                    left: `${calculateRangePosition(localFilter.Price.startPrice, localFilter.Price.endPrice).startPosition}%`,
+                    width: `${calculateRangePosition(localFilter.Price.startPrice, localFilter.Price.endPrice).endPosition - calculateRangePosition(localFilter.Price.startPrice, localFilter.Price.endPrice).startPosition}%`,
+                  }}
+                ></div>
                 {/* <div className="absolute top-0 left-1/2 transform -translate-x-1/2 h-full w-0.5 bg-black"></div> */}
                 <div className="absolute top-0 left-0 transform -translate-x-1/2 h-full w-0.5 bg-black"></div>
                 <div className="absolute top-0 right-0 transform translate-x-1/2 h-full w-0.5 bg-black"></div>
-                <div className="absolute top-0 left-1/2 transform -translate-x-1/2 h-full w-0.5 bg-black">
+                <div className={`absolute top-0 left-0 w-full h-full flex justify-center items-center text-lg font-bold text-orange-700`}>
+                  {data.price.toLocaleString()}円
+                </div>
+                {/* <div className="absolute top-0 left-1/2 transform -translate-x-1/2 h-full w-0.5 bg-black">
                   <span className="absolute top-full -translate-x-1/2 mt-1 text-xs"  style={{ whiteSpace: 'nowrap' }}>
                     {calculateUserSelectedPrice() != 0 ? calculateUserSelectedPrice().toLocaleString() + "円" : "1000円"}
                   </span>
-                </div>
+                </div> */}
               </div>
             ) : (
               <div
-                className="h-4 rounded-lg bg-gray-400 flex items-center justify-center text-white text-xs"
+                className="h-4 rounded-lg bg-gray-400 flex items-center justify-center text-white bg-green-400 text-xs"
                 style={{
                   width: '100%',
                 }}
@@ -223,33 +224,35 @@ const MatchIndicator: React.FC<MatchIndicatorProps> = ( props ) => {
             </div>
           }
         </div>
-        <div className="flex justify-between text-xs">
-          <span>0円</span>
-          <span>{(calculateUserSelectedPrice() * 2).toLocaleString()}円</span>
-        </div>
-        {data.price ? <small className="text-gray-400">価格:{data.price.toLocaleString()}円</small> : null}
+        {data.price && data.price != 0 ? (
+          <div className="flex justify-between text-xs">
+            <span>0円</span>
+            {/* <span>{(calculateUserSelectedPrice() * 2).toLocaleString()}円</span> */}
+            <span>10000円</span>
+          </div>
+        ) : null}
       </div>
 
       <div className="mb-4">
         <p>プレイモード</p>
-        {data.isMultiPlayer ?
-          <span className="px-2 py-1 bg-green-200 text-green-800 rounded">マルチプレイヤー</span>
-          : <span className="px-2 py-1 bg-gray-400 text-green-800 rounded">マルチプレイヤー</span>}
-        {data.isSinglePlayer ?
-          <span className="px-2 py-1 bg-green-200 text-green-800 rounded mr-1">シングルプレイヤー</span>
-          : <span className="px-2 py-1 bg-gray-400 text-green-800 rounded mr-1">シングルプレイヤー</span>}
+        <div className="flex">
+          <span className={`flex-1 px-2 py-1 rounded cursor-pointer text-center ${data.isMultiPlayer ? 'bg-green-200 text-green-800' : 'bg-gray-400 text-green-800'}`}>
+            マルチプレイヤー
+          </span>
+          <span className={`flex-1 px-2 py-1 rounded cursor-pointer text-center ${data.isSinglePlayer ? 'bg-green-200 text-green-800' : 'bg-gray-400 text-green-800'}`}>
+            シングルプレイヤー
+          </span>
+        </div>
 
         <p className='mt-3'>対応デバイス</p>
-        {data.device.windows ? (
-          <span className="px-2 py-1 bg-green-200 text-green-800 rounded">Windows</span>
-        ) : (
-          <span className="px-2 py-1 bg-gray-400 text-green-800 rounded">Windows</span>
-        )}
-        {data.device.mac ? (
-          <span className="px-2 py-1 bg-green-200 text-green-800 rounded">mac</span>
-        ) : (
-          <span className="px-2 py-1 bg-gray-400 text-green-800 rounded">mac</span>
-        )}
+        <div className="flex">
+          <span className={`flex-1 px-2 py-1 rounded cursor-pointer text-center ${data.device.windows ? 'bg-green-200 text-green-800' : 'bg-gray-400 text-green-800'}`}>
+            Windows
+          </span>
+          <span className={`flex-1 px-2 py-1 rounded cursor-pointer text-center ${data.device.mac ? 'bg-green-200 text-green-800' : 'bg-gray-400 text-green-800'}`}>
+            mac
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/src/components/popularity/FormatLabel.ts
+++ b/src/components/popularity/FormatLabel.ts
@@ -1,0 +1,24 @@
+import { timeFormat } from 'd3-time-format';
+
+// 日付を月/日または日で表示する関数
+export const formatDate = (date: Date, isFirstOfMonth: boolean) => {
+  if (isFirstOfMonth) {
+    return timeFormat('%-m/%-d')(date);
+  }
+  return timeFormat('%-d')(date);
+};
+
+// 月の初めの日付を判定するための関数
+export const getFirstOfMonthTicks = (dates: Date[]) => {
+  const months = new Set();
+  return dates.map(date => {
+    const month = date.getMonth();
+    const year = date.getFullYear();
+    const key = `${year}-${month}`;
+    if (!months.has(key)) {
+      months.add(key);
+      return { date, isFirstOfMonth: true };
+    }
+    return { date, isFirstOfMonth: false };
+  });
+};

--- a/src/components/popularity/Popularity.tsx
+++ b/src/components/popularity/Popularity.tsx
@@ -23,12 +23,24 @@ const Popularity = async(props:Props) => {
       {steamData && twitchData ? (
         <div className="flex">
           <div className="border border-gray-500 p-3">
-            <div className="text-white">Steamレビュー数</div>
-            <StackedAreaChart data={steamData} width={300} height={200} colorRange={STEAM_COLOR_RANGE}/>
+            <div className="text-white pb-3">Steamレビュー数</div>
+            <StackedAreaChart
+              data={steamData}
+              width={300}
+              height={200}
+              colorRange={STEAM_COLOR_RANGE}
+              labelTxt={{ bottom:'レビュー日（月/日）', left:'レビュー数（件）' }}
+            />
           </div>
           <div className="border border-gray-500 ml-2 p-3">
-            <div className="text-white">Twitch視聴数</div>
-            <StackedAreaChart data={twitchData} width={300} height={200} colorRange={TWITCH_COLOR_RANGE} />
+            <div className="text-white pb-3">Twitch視聴数</div>
+            <StackedAreaChart
+              data={twitchData}
+              width={300}
+              height={200}
+              colorRange={TWITCH_COLOR_RANGE}
+              labelTxt={{ bottom: "視聴日（月/日）", left: "視聴数（人）"}} 
+            />
           </div>
         </div>
       ) : null}

--- a/src/components/popularity/StackedAreaChart.tsx
+++ b/src/components/popularity/StackedAreaChart.tsx
@@ -6,6 +6,8 @@ import { CountSteamReviews } from '@/types/Popularity/CountSteamReviews';
 import { StackedAreasProps } from '@/types/Popularity/StackedAreaProps';
 import { AxisBottom, AxisLeft } from '@visx/axis';
 import { BG_COLOR_STACKED_AREA } from '@/constants/STYLES';
+import { curveBasis } from 'd3-shape';
+import { formatDate, getFirstOfMonthTicks } from './FormatLabel';
 
 const getX = (d: CountSteamReviews) => d.date * 1000;
 const getY0 = (d: SeriesPoint<CountSteamReviews>) => d[0];
@@ -15,15 +17,16 @@ const StackedAreaChart =({
   data,
   width,
   height,
+  labelTxt,
   margin = { top: 10, right: 0, bottom: 0, left: 0 },
-  events = false,
   colorRange,
 }: StackedAreasProps) => {
   const yMax = height - margin.top - margin.bottom;
   const xMax = width - margin.left - margin.right;
 
+  // データがない場合は何も表示しない
   if (!data || data.length === 0) {
-    return null; // データがない場合は何も表示しない
+    return <div className={`w-[${width + margin.left + margin.right}] h-[${height + margin.top + margin.bottom}]`}></div>;
   }
 
   const keys = Object.keys(data[0]).filter((k) => k !== 'date');
@@ -43,12 +46,38 @@ const StackedAreaChart =({
     domain: [0, Math.max(...data.map((d) => d.count))],
   }).nice();
 
+  const dates = data.map(d => new Date(d.date * 1000));
+  const firstOfMonthTicks = getFirstOfMonthTicks(dates);
 
-  return width < 10 ? null : (
+
+  return(
     <svg width={width+ 100} height={height +50}>
       <rect x={70} y={margin.top} width={width} height={height -margin.top} fill={BG_COLOR_STACKED_AREA} />
-      <AxisBottom scale={xScale} label='時間(年)' top={yMax+margin.top} left={70} hideZero numTicks={5} labelProps={{fill:'#e5e4e6'}} tickLabelProps={{fill: '#e5e4e6'}}/>
-      <AxisLeft scale={yScale} label='数' left={70} top={margin.top} labelOffset={50} labelProps={{fill:'#e5e4e6'}} tickLabelProps={{fill: '#e5e4e6'}} tickLineProps={{fill: '#e5e4e6'}}/>
+      <AxisBottom
+        scale={xScale}
+        label={labelTxt.bottom}
+        top={yMax+margin.top}
+        left={70}
+        hideZero
+        numTicks={5}
+        labelProps={{fill:'#e5e4e6'}}
+        tickLabelProps={{fill: '#e5e4e6'}}
+        tickFormat={(_value, index) => {
+          const { date, isFirstOfMonth } = firstOfMonthTicks[index];
+          return formatDate(date, isFirstOfMonth)
+        }}
+      />
+      <AxisLeft
+        scale={yScale}
+        label={labelTxt.left}
+        left={70}
+        top={margin.top}
+        labelOffset={50}
+        labelProps={{fill:'#e5e4e6'}}
+        tickLabelProps={{fill: '#e5e4e6'}}
+        tickLineProps={{fill: '#e5e4e6'}}
+        numTicks={7}
+      />
       <AreaStack
         top={margin.top}
         left={margin.left}
@@ -57,6 +86,7 @@ const StackedAreaChart =({
         x={(d) => xScale(getX(d.data)) + 70 ?? 0}
         y0={(d) => yScale(getY0(d)) + margin.top ?? 0}
         y1={(d) => yScale(getY1(d)) + margin.top ?? 0}
+        curve={ curveBasis }
       >
         {({ stacks, path }) =>
           stacks.map((stack) => {

--- a/src/hooks/createNetwork.ts
+++ b/src/hooks/createNetwork.ts
@@ -106,6 +106,9 @@ const createNetwork = async () => {
   const k = 4;
 
   const res = await fetch(`${process.env.NEXT_PUBLIC_CURRENT_URL}/api/network/getMatchGames`);
+  if(!res) {
+    return {};
+  }
   const data:gameDetailType[] = await res.json();
 
   const d = await getFilterData('unique_id');

--- a/src/types/Popularity/StackedAreaProps.ts
+++ b/src/types/Popularity/StackedAreaProps.ts
@@ -4,6 +4,7 @@ export type StackedAreasProps = {
   data: CountSteamReviews[],
   width: number;
   height: number;
+  labelTxt: { bottom: string; left: string };
   events?: boolean;
   margin?: { top: number; right: number; bottom: number; left: number };
   colorRange: string[];


### PR DESCRIPTION
- ラベル表記を SteamとTwitchそれぞれ対応
- ｙ軸ラベルがきつきつだったので分割数を変更
- グラフが折れ線が見にくかったので曲線に変更
- 目盛りは各月の最初の値のみ　月/日　表示、それ以外では　日　のみ表示に変更