### PR TITLE
ネットワークグラフで表示が小さくなる問題

### DIFF
--- a/src/app/api/getSteamGameDetail/[steamGameId]/route.ts
+++ b/src/app/api/getSteamGameDetail/[steamGameId]/route.ts
@@ -1,0 +1,162 @@
+import { PG_POOL } from "@/constants/PG_POOL";
+import { NextResponse } from "next/server";
+
+type Params = {
+  params: {
+    steamGameId: string;
+  };
+};
+
+export async function GET(req: Request, { params }: Params) {
+  const steamGameId = params.steamGameId;
+
+  try {
+    const today = new Date(2025, 0, 21);
+    // 過去一週間のデータを取得（昨日までの7日間）
+    const endDate = new Date(today);
+    endDate.setDate(endDate.getDate() - 1);
+    const startDate = new Date(today);
+    startDate.setDate(startDate.getDate() - 7);
+
+    const endDateString = endDate.toISOString().split("T")[0];
+    const startDateString = startDate.toISOString().split("T")[0];
+
+    // **1. steam_game_data から基本情報を取得**
+    const baseQuery = `
+      SELECT 
+          sd.steam_game_id, 
+          sd.twitch_game_id, 
+          sd.game_title AS name, 
+          sd.webpage_url AS url, 
+          sd.img_url AS image, 
+          sd.price,
+          sd.is_single_player, 
+          sd.is_multi_player, 
+          sd.is_device_windows, 
+          sd.is_device_mac,
+          sd.genres,
+          sd.tags,
+          sd.short_details,
+          sd.release_date,
+          sd.developer_name,
+          sd.review_text,
+          sd.similar_games,
+          sd.feature_vector,
+          sd.background,
+          sd.screenshots,
+          sd.mp4_movies
+      FROM 
+          steam_game_data sd
+      WHERE 
+          sd.steam_game_id = $1;
+    `;
+
+    const { rows: baseRows } = await PG_POOL.query(baseQuery, [steamGameId]);
+
+    if (baseRows.length === 0) {
+      return NextResponse.json({ error: "Game not found" }, { status: 404 });
+    }
+
+    const baseData = baseRows[0];
+
+    // **2. game_views から統計情報を取得**
+    const statsQuery = `
+      SELECT 
+        gv.steam_id,
+        MAX(gv.twitch_id) AS twitch_id,
+        SUM(gv.total_views) AS total_views,
+        COALESCE(SUM(sa.active_user), 0) AS total_active_users
+      FROM 
+        game_views gv
+      LEFT JOIN
+        steam_active_users sa
+        ON gv.steam_id = CAST(sa.steam_id AS TEXT) AND gv.get_date::date = sa.get_date
+      WHERE 
+        gv.steam_id = CAST($3 AS TEXT) AND
+        gv.get_date::date BETWEEN $1 AND $2
+      GROUP BY
+        gv.steam_id;
+    `;
+
+    const { rows: statsRows } = await PG_POOL.query(statsQuery, [
+      startDateString,
+      endDateString,
+      steamGameId
+    ]);
+
+    let similarGames: string[] = [];
+    similarGames = [
+      ...new Set(baseData.similar_games["released"] as string[]),
+    ];
+
+    if (statsRows.length === 0) {
+      // **統計データがない場合は baseData のみを返す**
+      return NextResponse.json({
+        twitchGameId: baseData.twitch_game_id,
+        steamGameId: baseData.steam_game_id,
+        title: baseData.name,
+        imgURL: baseData.image,
+        url: baseData.url,
+        totalViews: 0,
+        activeUsers: 0,
+        genres: baseData.genres || [],
+        price: baseData.price,
+        isSinglePlayer: baseData.is_single_player,
+        isMultiPlayer: baseData.is_multi_player,
+        device: {
+          windows: baseData.is_device_windows,
+          mac: baseData.is_device_mac,
+        },
+        tags: baseData.tags || [],
+        shortDetails: baseData.short_details,
+        releaseDate: baseData.release_date,
+        developerName: baseData.developer_name,
+        review: baseData.review_text,
+        similarGames: similarGames || [],
+        featureVector: baseData.feature_vector || [],
+        background: baseData.background || "",
+        screenshots: baseData.screenshots || [],
+        mp4Movies: baseData.mp4_movies || [],
+      });
+    }
+
+    const statsData = statsRows[0];
+
+    // **3. データを統合して返す**
+    const result = {
+      twitchGameId: baseData.twitch_game_id,
+      steamGameId: baseData.steam_game_id,
+      title: baseData.name,
+      imgURL: baseData.image,
+      url: baseData.url,
+      totalViews: parseInt(statsData.total_views, 10),
+      activeUsers: parseInt(statsData.total_active_users, 10),
+      genres: baseData.genres || [],
+      price: baseData.price,
+      isSinglePlayer: baseData.is_single_player,
+      isMultiPlayer: baseData.is_multi_player,
+      device: {
+        windows: baseData.is_device_windows,
+        mac: baseData.is_device_mac,
+      },
+      tags: baseData.tags || [],
+      shortDetails: baseData.short_details,
+      releaseDate: baseData.release_date,
+      developerName: baseData.developer_name,
+      review: baseData.review_text,
+      similarGames: similarGames || [],
+      featureVector: baseData.feature_vector || [],
+      background: baseData.background || "",
+      screenshots: baseData.screenshots || [],
+      mp4Movies: baseData.mp4_movies || [],
+    };
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error fetching game details:", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -68,8 +68,6 @@ const Network = () => {
 
   const { tourRun, setTourRun } = useTour();
 
-  const [userAddedGames, setUserAddedGames] = useState<string[]>([]);
-
   const [prevAddedGameId, setPrevAddedGameId] = useState<string>("");
 
   const initialNodes = async (
@@ -87,18 +85,10 @@ const Network = () => {
       const buffNodes = [...rawNodes].sort(
         (node1, node2) => (node2.circleScale ?? 0) - (node1.circleScale ?? 0)
       );
-      const index = buffNodes.findIndex(
-        (node: NodeType) => node.steamGameId === prevAddedGameId
-      );
-      if (buffNodes.length > 0 && index === -1) {
-        setCenterX((buffNodes[0]?.x ?? 0) - 150);
-        setCenterY((buffNodes[0]?.y ?? 0) + 100);
-        setSelectedIndex(-1);
-      } else if (index !== -1) {
-        setCenterX((buffNodes[index]?.x ?? 0) - 150);
-        setCenterY((buffNodes[index]?.y ?? 0) + 100);
-        setSelectedIndex(index);
-      }
+      setCenterX((buffNodes[0]?.x ?? 0) - 150);
+      setCenterY((buffNodes[0]?.y ?? 0) + 100);
+      setSelectedIndex(-1);
+      
       setPrevAddedGameId("");
       setNodes(rawNodes);
       setLinks(rawLinks);

--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -179,14 +179,6 @@ const Network = () => {
     });
   };
 
-  // ユーザーが追加したゲームを取得
-  useEffect(() => {
-    (async () => {
-      const res = await getGameIdData();
-      setUserAddedGames(res ?? []);
-    })();
-  }, []);
-
   // データ取得失敗
   if (!steamAllData || !steamListData) {
     return <Loading />;
@@ -216,8 +208,6 @@ const Network = () => {
 
         <SearchGames
           setSelectedIndex={setSelectedIndex}
-          userAddedGames={userAddedGames}
-          setUserAddedGames={setUserAddedGames}
           nodes={nodes}
           setIsNetworkLoading={setIsNetworkLoading}
           steamListData={steamListData}
@@ -378,8 +368,6 @@ const Network = () => {
             nodes={nodes}
             selectedIndex={selectedIndex}
             setSelectedIndex={setSelectedIndex}
-            userAddedGames={userAddedGames}
-            setUserAddedGames={setUserAddedGames}
             setIsNetworkLoading={setIsNetworkLoading}
           />
         </div>

--- a/src/components/common/Headers.tsx
+++ b/src/components/common/Headers.tsx
@@ -1,7 +1,7 @@
 export const HomeHeader = () => {
   return (
     <header className="absolute top-0 w-full h-[8vh] bg-gradient-to-b from-gray-800 to-transparent text-white flex items-center justify-center z-10 select-none">
-      <h1 className="text-4xl font-bold">Steam Suggester</h1>
+      <div className="text-2xl font-bold md:text-3xl lg:text-4xl">Steam Suggester</div>
     </header>
   );
 };

--- a/src/components/common/Utils.ts
+++ b/src/components/common/Utils.ts
@@ -1,0 +1,13 @@
+export const startsWith = (str: string | null, prefix: string) => {
+  if (str === null || str === undefined) {
+    return false;
+  }
+  return str?.startsWith(prefix);
+};
+
+export const startsWithPanelList = (str: string | null) => {
+  if (str === null || str === undefined) {
+    return false;
+  }
+  return str && ["streamer", "highlight", "steamList", "ranking", "similarity", "filter"].includes(str);
+}

--- a/src/components/detail/GameDetail.tsx
+++ b/src/components/detail/GameDetail.tsx
@@ -74,7 +74,7 @@ const GameDetail = (props: Props) => {
   }, [node]);
 
   return (
-    <div className="flex-1 bg-gray-800 rounded-l-lg shadow-md flex flex-col space-y-4 overflow-y-scroll h-full relative">
+    <div className="flex-1 bg-gray-800 rounded-l-lg shadow-md flex flex-col space-y-4 relative">
       {/* 選択されたゲームの詳細表示 */}
       {node ? (
         <div className="rounded-lg">

--- a/src/components/detail/GameDetail.tsx
+++ b/src/components/detail/GameDetail.tsx
@@ -228,27 +228,30 @@ const GameDetail = (props: Props) => {
             {node.review && <ReviewCloud reviewData={node.review} />}
           </div>
 
-          <Box
-            sx={{ borderBottom: 1, borderColor: "divider", marginBottom: 2 }}
-          >
-            <Tabs
-              value={tabIndex}
-              onChange={handleChange}
-              aria-label="basic tabs example"
-              centered
+          {node.twitchGameId !== "" && (
+
+            <Box
+              sx={{ borderBottom: 1, borderColor: "divider", marginBottom: 2 }}
             >
-              <Tab
-                label="流行度グラフ"
-                {...a11yProps(0)}
-                sx={{ color: "white" }}
-              />
-              <Tab
-                label="Twitchクリップ"
-                {...a11yProps(1)}
-                sx={{ color: "white" }}
-              />
-            </Tabs>
-          </Box>
+              <Tabs
+                value={tabIndex}
+                onChange={handleChange}
+                aria-label="basic tabs example"
+                centered
+              >
+                <Tab
+                  label="流行度グラフ"
+                  {...a11yProps(0)}
+                  sx={{ color: "white" }}
+                />
+                <Tab
+                  label="Twitchクリップ"
+                  {...a11yProps(1)}
+                  sx={{ color: "white" }}
+                />
+              </Tabs>
+            </Box>
+          )}
 
           {tabIndex === 0 && <PopularityCharts node={node} />}
           {tabIndex === 1 && (

--- a/src/components/detail/PopularityCharts.tsx
+++ b/src/components/detail/PopularityCharts.tsx
@@ -12,7 +12,7 @@ type Props = {
   node: NodeType;
 };
 
-const PopularityCharts = ({ node }:Props) => {
+const PopularityCharts = ({ node }: Props) => {
   const { data: steamData, error: steamError } = useSWR(
     node
       ? `${process.env.NEXT_PUBLIC_CURRENT_URL}/api/details/countRecentSteamReviews/${node.steamGameId}`
@@ -21,7 +21,7 @@ const PopularityCharts = ({ node }:Props) => {
   );
 
   const { data: twitchData, error: twitchError } = useSWR(
-    node
+    node && node.twitchGameId
       ? `${process.env.NEXT_PUBLIC_CURRENT_URL}/api/details/getTwitchViews/${node.twitchGameId}`
       : null,
     fetcher
@@ -40,18 +40,18 @@ const PopularityCharts = ({ node }:Props) => {
     );
   }
 
-  if (!steamData || !twitchData || !activeUsersData) {
-    return (
-      <div className="flex justify-center items-center h-32">
-        <CircularProgress />
-      </div>
-    );
-  }
-
   if (steamError || twitchError || activeUsersError) {
     return (
       <div className="text-red-500 text-center">
         データの取得に失敗しました。
+      </div>
+    );
+  }
+
+  if (!steamData || !activeUsersData || (node.twitchGameId && !twitchData)) {
+    return (
+      <div className="flex justify-center items-center h-32">
+        <CircularProgress />
       </div>
     );
   }
@@ -62,7 +62,9 @@ const PopularityCharts = ({ node }:Props) => {
       <AreaRechart data={steamData} xKey="date" yKey="count" color={STEAM_COLOR_RANGE[0]} title="Steamレビュー数" />
 
       {/* Twitch視聴数 */}
-      <AreaRechart data={twitchData} xKey="date" yKey="count" color={TWITCH_COLOR_RANGE[0]} title="Twitch視聴数" />
+      {node.twitchGameId && (
+        <AreaRechart data={twitchData} xKey="date" yKey="count" color={TWITCH_COLOR_RANGE[0]} title="Twitch視聴数" />
+      )}
 
       {/* アクティブユーザー数 */}
       <AreaRechart data={activeUsersData} xKey="get_date" yKey="active_user" color={STEAM_COLOR_RANGE[0]} title="アクティブユーザー数" />

--- a/src/components/nodelink/GameTooltip.tsx
+++ b/src/components/nodelink/GameTooltip.tsx
@@ -65,8 +65,6 @@ const GameTooltip: React.FC<GameTooltipProps> = ({
     }
   }, []);
 
-  console.log(secureUrl);
-
   return (
     <g
       transform={`translate(${x},${y}) scale(${1 / transform.k})`}

--- a/src/components/nodelink/GameTooltip.tsx
+++ b/src/components/nodelink/GameTooltip.tsx
@@ -36,6 +36,7 @@ const GameTooltip: React.FC<GameTooltipProps> = ({
 
   const hasVideos = videoUrls.length > 0;
   const videoUrl = hasVideos ? videoUrls[0] : "";
+  const secureUrl = videoUrl.replace("http://", "https://");
 
   // スライドショーのタイマー
   useEffect(() => {
@@ -63,6 +64,8 @@ const GameTooltip: React.FC<GameTooltipProps> = ({
       });
     }
   }, []);
+
+  console.log(secureUrl);
 
   return (
     <g
@@ -107,7 +110,7 @@ const GameTooltip: React.FC<GameTooltipProps> = ({
           >
             {hasVideos ? (
               <video
-                src={videoUrl}
+                src={secureUrl}
                 autoPlay
                 muted
                 loop

--- a/src/components/nodelink/NodeLink.tsx
+++ b/src/components/nodelink/NodeLink.tsx
@@ -13,6 +13,7 @@ import HighlightTag from "./highlight/HighlightTag";
 import HighlightSteamList from "./highlight/HighlightSteamList";
 import NonSelectedLinks from "./parts/NonSelectedLinks";
 import SelectedLinks from "./parts/SelectedLinks";
+import { startsWith } from "../common/Utils";
 
 const DEFAULT_TOOLTIP = {
   index: -1,
@@ -247,7 +248,7 @@ const NodeLink = (props: NodeLinkProps) => {
                       similarGamesLinkList={selectedLinks}
                     />
                     {/* 色付きセグメントを描画 配信者による強調 */}
-                    {openPanel === "streamer" && (
+                    {startsWith(openPanel, "streamer") && (
                       <HighlightStreamer
                         streamerIds={streamerIds}
                         twitchGameId={node.twitchGameId}
@@ -255,7 +256,7 @@ const NodeLink = (props: NodeLinkProps) => {
                       />
                     )}
 
-                    {openPanel === "highlight" && (
+                    {startsWith(openPanel, "highlight") && (
                       <HighlightTag
                         tags={node.tags || []}
                         selectedTags={selectedTags}
@@ -264,7 +265,7 @@ const NodeLink = (props: NodeLinkProps) => {
                       />
                     )}
 
-                    {openPanel === "steamList" && (
+                    {startsWith(openPanel, "steamList") && (
                       <HighlightSteamList
                         myGamesError={myGamesError}
                         friendsGamesError={friendsGamesError}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -7,12 +7,16 @@ import SportsEsportsOutlinedIcon from "@mui/icons-material/SportsEsportsOutlined
 import LeaderboardOutlinedIcon from "@mui/icons-material/LeaderboardOutlined";
 import HighlightOutlinedIcon from "@mui/icons-material/HighlightOutlined";
 import TourOutlinedIcon from "@mui/icons-material/TourOutlined";
+import { startsWith } from "../common/Utils";
 
 // 共通のボタンクラス
-export const buttonClasses = (isActive: boolean) =>
-  `w-full py-2 text-center flex flex-col items-center ${
-    isActive ? "bg-gray-700" : "hover:bg-gray-700"
-  } rounded transition-colors duration-200`;
+const buttonClasses = (isActive: boolean) =>
+`w-full py-2 text-center flex flex-col items-center ${
+  isActive ? "bg-gray-700" : "hover:bg-gray-700"
+} rounded transition-colors duration-200`;
+
+const titleClasses = () =>
+"text-xs mt-1 hidden lg:inline-block";
 
 type Props = {
   openPanel: string | null;
@@ -28,67 +32,67 @@ const Sidebar: React.FC<Props> = ({
   toggleTourRun,
 }) => {
   return (
-    <div className="w-24 bg-gray-800 text-white flex flex-col items-center py-4 space-y-4 z-10">
+    <div className="bg-gray-800 text-white flex flex-col items-center py-4 space-y-4 z-10 w-[10vw] max-w-16 lg:w-24 lg:max-w-24">
       {/* 上部ボタン群 */}
       <div className="flex flex-col items-center space-y-4 flex-grow select-none">
         {/* ランキングボタン */}
         <button
           onClick={() => togglePanel("ranking")}
-          className={`${buttonClasses(openPanel === "ranking")} step5`}
+          className={`${buttonClasses(startsWith(openPanel, "ranking"))} step5`}
         >
           <LeaderboardOutlinedIcon />
-          <span className="text-xs mt-1">ランキング</span>
+          <span className={titleClasses()}>ランキング</span>
         </button>
         {/* 区切り線 */}
         <div className="w-full border-t border-gray-700 my-2"></div>
         {/* Steamリストボタン */}
         <button
           onClick={() => togglePanel("steamList")}
-          className={`${buttonClasses(openPanel === "steamList")} step4`}
+          className={`${buttonClasses(startsWith(openPanel, "steamList"))} step4`}
         >
           <SportsEsportsOutlinedIcon />
-          <span className="text-xs mt-1">Steam連携</span>
+          <span className={titleClasses()}>Steam連携</span>
         </button>
         {/* 強調表示ボタン */}
         <button
           onClick={() => togglePanel("highlight")}
-          className={`${buttonClasses(openPanel === "highlight")} `}
+          className={`${buttonClasses(startsWith(openPanel, "highlight"))} `}
         >
           <HighlightOutlinedIcon />
-          <span className="text-xs mt-1">強調表示</span>
+          <span className={titleClasses()}>強調表示</span>
         </button>
         {/* Streamerボタン */}
         <button
           onClick={() => togglePanel("streamer")}
-          className={`${buttonClasses(openPanel === "streamer")} step2`}
+          className={`${buttonClasses(startsWith(openPanel, "streamer"))} step2`}
         >
           <LiveTvOutlinedIcon />
-          <span className="text-xs mt-1">配信者</span>
+          <span className={titleClasses()}>配信者</span>
         </button>
         {/* 区切り線 */}
         <div className="w-full border-t border-gray-700 my-2"></div>
         {/* 類似度ボタン */}
         <button
           onClick={() => togglePanel("similarity")}
-          className={`${buttonClasses(openPanel === "similarity")} step3`}
+          className={`${buttonClasses(startsWith(openPanel, "similarity"))} step3`}
         >
           <TuneOutlinedIcon />
-          <span className="text-xs mt-1">類似度設定</span>
+          <span className={titleClasses()}>類似度設定</span>
         </button>
         {/* フィルターボタン */}
         <button
           onClick={() => togglePanel("filter")}
-          className={`${buttonClasses(openPanel === "filter")} step1`}
+          className={`${buttonClasses(startsWith(openPanel, "filter"))} step1`}
         >
           <FilterListOutlinedIcon />
-          <span className="text-xs mt-1">フィルター</span>
+          <span className={titleClasses()}>フィルター</span>
         </button>
       </div>
 
       {/* ツアーボタン */}
       <button onClick={toggleTourRun} className={`${buttonClasses(tourRun)}`}>
         <TourOutlinedIcon />
-        <span className="text-xs mt-1">チュートリアル</span>
+        <span className={titleClasses()}>チュートリアル</span>
       </button>
     </div>
   );

--- a/src/components/sidebar/leaderboard/Leaderboard.tsx
+++ b/src/components/sidebar/leaderboard/Leaderboard.tsx
@@ -1,18 +1,16 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { NodeType } from "@/types/NetworkType";
 import HelpTooltip from "../../common/HelpTooltip";
 import LeaderboardOutlinedIcon from "@mui/icons-material/LeaderboardOutlined";
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
-import { changeGameIdData } from "@/hooks/indexedDB";
+import { changeGameIdData, getGameIdData } from "@/hooks/indexedDB";
 
 type Props = {
   nodes: NodeType[];
   selectedIndex: number;
   setSelectedIndex: React.Dispatch<React.SetStateAction<number>>;
-  userAddedGames: string[];
-  setUserAddedGames: React.Dispatch<React.SetStateAction<string[]>>;
   setIsNetworkLoading: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
@@ -20,10 +18,20 @@ const Leaderboard: React.FC<Props> = ({
   nodes,
   selectedIndex,
   setSelectedIndex,
-  userAddedGames,
-  setUserAddedGames,
   setIsNetworkLoading,
 }) => {
+
+  const [addedGameIds, setAddedGameIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    const fetchGameIds = async () => {
+      const addedGameIds = await getGameIdData();
+      setAddedGameIds(addedGameIds ?? []);
+    };
+    fetchGameIds();
+  }, [nodes]);
+
+
   // ランキング順にソート
   const sortedNodes = [...nodes].sort(
     (a, b) => (b.circleScale ?? 0) - (a.circleScale ?? 0)
@@ -51,7 +59,7 @@ const Leaderboard: React.FC<Props> = ({
       </div>
       <ul>
         {sortedNodes.map((node, index) => {
-          const isUserAdded = userAddedGames.find(
+          const isUserAdded = addedGameIds.find(
             (gameId: string) => gameId === node.steamGameId
           );
           const titleColor = isUserAdded ? "green-300" : "white";
@@ -80,10 +88,9 @@ const Leaderboard: React.FC<Props> = ({
                   className="flex items-center justify-center p-1 hover:bg-red-500 rounded cursor-pointer"
                   onClick={(e) => {
                     e.stopPropagation();
-                    const newUserAddedGames = userAddedGames.filter(
+                    const newUserAddedGames = addedGameIds.filter(
                       (gameId: string) => gameId !== node.steamGameId
                     );
-                    setUserAddedGames(newUserAddedGames);
                     (async () => {
                       await changeGameIdData(newUserAddedGames);
                       setIsNetworkLoading(true);

--- a/src/components/sidebar/leaderboard/Leaderboard.tsx
+++ b/src/components/sidebar/leaderboard/Leaderboard.tsx
@@ -59,10 +59,8 @@ const Leaderboard: React.FC<Props> = ({
       </div>
       <ul>
         {sortedNodes.map((node, index) => {
-          const isUserAdded = addedGameIds.find(
-            (gameId: string) => gameId === node.steamGameId
-          );
-          const titleColor = isUserAdded ? "green-300" : "white";
+          const isUserAdded = addedGameIds.find((gameId: string) => gameId === node.steamGameId);
+          const titleColor = isUserAdded ? "text-green-300" : "text-white";
 
           const isSelected = selectedIndex === node.index; // 選択状態を判定
 
@@ -79,7 +77,7 @@ const Leaderboard: React.FC<Props> = ({
                 <span className={`${selectColor(index + 1).rankColor} mr-2`}>
                   {index + 1}位
                 </span>
-                <span className={`text-${titleColor}`}>{node.title}</span>
+                <span className={`${titleColor}`}>{node.title}</span>
               </div>
 
               {/* ゴミ箱アイコン */}

--- a/src/components/sidebar/searchGames/SearchGames.tsx
+++ b/src/components/sidebar/searchGames/SearchGames.tsx
@@ -7,6 +7,8 @@ import DeleteForeverOutlinedIcon from "@mui/icons-material/DeleteForeverOutlined
 import SearchIcon from "@mui/icons-material/Search";
 import PlaylistAddIcon from "@mui/icons-material/PlaylistAdd";
 import { IconButton } from "@mui/material";
+import useScreenSize from "@visx/responsive/lib/hooks/useScreenSize";
+import { startsWithPanelList } from "@/components/common/Utils";
 
 type SearchGamesProps = {
   setSelectedIndex: (value: number) => void;
@@ -29,6 +31,8 @@ const SearchGames = ({
   const [filteredSteamList, setFilteredSteamList] = useState<SteamListType[]>([]);
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [addedGameIds, setAddedGameIds] = useState<string[]>([]);
+
+  const { width, height } = useScreenSize({ debounceTime: 150 });
 
 
   // 外部クリックを検出してフォーカスを解除
@@ -129,12 +133,16 @@ const SearchGames = ({
     }
   };
 
+  if (width < 1024 && startsWithPanelList(openPanel)) {
+    return null;
+  }
+
   return (
     <div
       id="search-container"
-      className={`absolute top-4 z-30 py-2 rounded-lg backdrop-filter backdrop-blur-sm transition-all duration-300 ease-in-out`}
+      className={`absolute z-30 py-2 rounded-lg transition-all duration-300 ease-in-out top-12 lg:top-4`}
       style={{
-        marginLeft: openPanel ? "calc(20% + 1rem)" : "1rem", // Sidebarの幅に応じてマージンを変更
+        marginLeft: startsWithPanelList(openPanel) ? "calc(20% + 1rem)" : "1rem", // Sidebarの幅に応じてマージンを変更
       }}
     >
       {/* 検索フォーム */}

--- a/src/components/sidebar/selectParameter/SelectParameter.tsx
+++ b/src/components/sidebar/selectParameter/SelectParameter.tsx
@@ -124,10 +124,7 @@ const SelectParameter: React.FC<Props> = ({
       <div className="flex flex-col h-full">
 
         {/* タグフィルター */}
-        <Section title="タグ" icon={<TagOutlinedIcon />}>
-          <p className="text-sm text-white mb-4">
-            指定のタグを含むゲームを表示します。
-          </p>
+        <Section title="取り除くタグ" icon={<TagOutlinedIcon />}>
           <Button
             onClick={() => setSelectedTags([])}
             variant="outlined"

--- a/src/components/sidebar/selectParameter/SelectParameter.tsx
+++ b/src/components/sidebar/selectParameter/SelectParameter.tsx
@@ -116,7 +116,7 @@ const SelectParameter: React.FC<Props> = ({
       title={
         <div className="flex items-center">
           <span>フィルター</span>
-          <HelpTooltip title="フィルターを適用することでゲームの絞り込みができます。" />
+          <HelpTooltip title="フィルターを適用することで独自のグラフを生成できます。" />
         </div>
       }
       icon={<FilterListIcon className="mr-2 text-white" />}

--- a/src/components/sidebar/selectParameter/SelectParameter.tsx
+++ b/src/components/sidebar/selectParameter/SelectParameter.tsx
@@ -122,6 +122,27 @@ const SelectParameter: React.FC<Props> = ({
       icon={<FilterListIcon className="mr-2 text-white" />}
     >
       <div className="flex flex-col h-full">
+
+        {/* タグフィルター */}
+        <Section title="タグ" icon={<TagOutlinedIcon />}>
+          <p className="text-sm text-white mb-4">
+            指定のタグを含むゲームを表示します。
+          </p>
+          <Button
+            onClick={() => setSelectedTags([])}
+            variant="outlined"
+            startIcon={<RefreshIcon />}
+            sx={{ mb: 2 }}
+          >
+            <span className="text-blue-300">リセット</span>
+          </Button>
+          <TagsSelect
+            selectedTags={selectedTags}
+            setSelectedTags={setSelectedTags}
+          />
+        </Section>
+
+
         {/* 価格フィルター */}
         <Section title="価格" icon={<AttachMoneyIcon />}>
           <div className="flex items-center mb-4">

--- a/src/components/sidebar/steamList/FriendGameItem.tsx
+++ b/src/components/sidebar/steamList/FriendGameItem.tsx
@@ -12,7 +12,7 @@ const FriendGameItem = ({ game, onSelect, nodeIndex }: FriendGameItemProps) => {
   return (
     <div className="p-2 mb-2 bg-gray-900 rounded-lg relative group">
       <div className="flex items-center justify-between">
-        <div className="p-2" onClick={onSelect}>
+        <div className="p-2 " onClick={onSelect}>
           {game.gameName}
           {nodeIndex !== -1 &&
             <IconButton size="small" sx={{ color: "white" }} onClick={onSelect}>
@@ -20,13 +20,15 @@ const FriendGameItem = ({ game, onSelect, nodeIndex }: FriendGameItemProps) => {
             </IconButton>
           }
         </div>
-        <AvatarGroup max={3} spacing={"small"}>
-          {game.friends.map((friend, friendIndex) => (
-            <Avatar key={friendIndex} alt={friend.name} src={friend.avatar} />
-          ))}
-        </AvatarGroup>
+        <div className="hidden md:inline-block">
+          <AvatarGroup max={3} spacing={"small"}>
+            {game.friends.map((friend, friendIndex) => (
+              <Avatar key={friendIndex} alt={friend.name} src={friend.avatar} />
+            ))}
+          </AvatarGroup>
+        </div>
       </div>
-      <div className="absolute left-1/2 w-64 top-full mt-2 -translate-x-1/2 bg-gray-800 text-white p-4 rounded-lg border border-gray-600 shadow-xl z-50 hidden group-hover:block opacity-0 group-hover:opacity-100">
+      <div className="absolute left-1/2 w-64 top-full mt-2 -translate-x-1/2 bg-gray-800 text-white p-4 rounded-lg border border-gray-600 shadow-xl z-50 hidden group-hover:block opacity-0 group-hover:opacity-100 invisible lg:visible">
         <h4 className="text-lg font-bold mb-2">所持しているフレンドリスト</h4>
         <ul>
           {game.friends.map((friend, friendIndex) => (

--- a/src/components/sidebar/steamList/SteamList.tsx
+++ b/src/components/sidebar/steamList/SteamList.tsx
@@ -178,7 +178,7 @@ const SteamList = (props: Props) => {
         </div>
 
         {/* 自分の所有ゲーム */}
-        <Section title="自分の所有ゲーム" icon={<PersonIcon />}>
+        <Section title={`自分の所有ゲーム(${myOwnGames.length})`} icon={<PersonIcon />}>
           <Button onClick={addOwnedGamesToNode}>追加してないゲームをすべて追加</Button>
           <div className="bg-gray-700 p-2 rounded-lg overflow-y-auto ">
             {myOwnGames.length > 0 ? (
@@ -204,7 +204,7 @@ const SteamList = (props: Props) => {
         </Section>
 
         {/* フレンドの所有ゲーム */}
-        <Section title="フレンドの所有ゲーム" icon={<GroupIcon />}>
+        <Section title={`フレンドの所有ゲーム(${friendsOwnGames.length})`} icon={<GroupIcon />}>
         <Button onClick={addFriendGamesToNode}>追加してないゲームをすべて追加</Button>
           <div className="bg-gray-700 p-2 rounded-lg overflow-y-auto">
             {friendsOwnGames.length > 0 ? (

--- a/src/hooks/changeNetwork.ts
+++ b/src/hooks/changeNetwork.ts
@@ -149,7 +149,6 @@ export default async function changeNetwork(
       const url = `${process.env.NEXT_PUBLIC_CURRENT_URL}/api/getSteamGameDetail/${gameId}`;
       try {
         const d: SteamDetailsDataType = await fetchWithCache(url);
-        console.log(gameId, d)
         slicedData.push(d);
       } catch (error) {
         console.error(error);
@@ -157,7 +156,6 @@ export default async function changeNetwork(
     });
   await Promise.all(promises);
 
-  console.log("slicedData", slicedData);
 
   // フィルターに合致するデータだけ取り出す
   const rawNodes = slicedData.filter((item) => {

--- a/src/hooks/changeNetwork.ts
+++ b/src/hooks/changeNetwork.ts
@@ -146,15 +146,18 @@ export default async function changeNetwork(
   const promises = gameIds
     .filter((gameId) => !slicedData.find((d) => d.steamGameId === gameId))
     .map(async (gameId) => {
-      const url = `${process.env.NEXT_PUBLIC_CURRENT_URL}/api/details/getSteamGameDetail/${gameId}`;
+      const url = `${process.env.NEXT_PUBLIC_CURRENT_URL}/api/getSteamGameDetail/${gameId}`;
       try {
         const d: SteamDetailsDataType = await fetchWithCache(url);
+        console.log(gameId, d)
         slicedData.push(d);
       } catch (error) {
         console.error(error);
       }
     });
   await Promise.all(promises);
+
+  console.log("slicedData", slicedData);
 
   // フィルターに合致するデータだけ取り出す
   const rawNodes = slicedData.filter((item) => {

--- a/src/hooks/createNetwork.ts
+++ b/src/hooks/createNetwork.ts
@@ -112,7 +112,6 @@ const createNetwork = async (
       const url = `${process.env.NEXT_PUBLIC_CURRENT_URL}/api/getSteamGameDetail/${gameId}`;
       try {
         const d: SteamDetailsDataType = await fetchWithCache(url);
-        console.log(d)
         slicedData.push(d);
       } catch (error) {
         console.error(error);

--- a/src/hooks/createNetwork.ts
+++ b/src/hooks/createNetwork.ts
@@ -109,9 +109,10 @@ const createNetwork = async (
   const promises = gameIds
     .filter((gameId) => !slicedData.find((d) => d.steamGameId === gameId))
     .map(async (gameId, index, array) => {
-      const url = `${process.env.NEXT_PUBLIC_CURRENT_URL}/api/details/getSteamGameDetail/${gameId}`;
+      const url = `${process.env.NEXT_PUBLIC_CURRENT_URL}/api/getSteamGameDetail/${gameId}`;
       try {
         const d: SteamDetailsDataType = await fetchWithCache(url);
+        console.log(d)
         slicedData.push(d);
       } catch (error) {
         console.error(error);


### PR DESCRIPTION
### 原因
追加取得APIでユーザー数とってないのにユーザー数でサイズ調整してたから、スケール効かなくて小さくなってたぽい
タグ関係ないバグでした、なので自環境だと検索から追加する時にも起きるバグだった
なんで気付かなかっただろう

### 応急処置
新規API（/api/getSteamGameDetail/steamGameId）を作成
まずもともとのAPI（/api/getSteamGameDetail/steamGameId）と同じ処理をして、そのあとにアクティブユーザーとか取得した
もしアクティブユーザとか取れないよとか怒られたら、もともとのAPIと同じデータを返してる
取れた場合は合体させたデータを返してます
これで一旦は動くかな

- ただここらへんの型は、アクティブユーザー数でスケールしてるとこの変更とかあれば適宜APIを変更してください

